### PR TITLE
Update entry points for mcp-server to use index.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"zod": "^3.24.3"
 			},
 			"bin": {
-				"mcp-server": "dist/server.js"
+				"mcp-server": "dist/index.js"
 			},
 			"devDependencies": {
 				"@biomejs/biome": "1.9.4",

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
 		"yaml": "^2.7.1"
 	},
 	"type": "module",
-	"main": "src/server.ts",
+	"main": "src/index.ts",
 	"bin": {
-		"mcp-server": "dist/server.js"
+		"mcp-server": "dist/index.js"
 	},
 	"scripts": {
 		"build": "run-s build:*",


### PR DESCRIPTION
This pull request modifies the entry points for the application in the `package.json` file. The changes ensure consistency between the main module and the binary entry point.

Key changes:

* Updated the `main` field to point to `src/index.ts` instead of `src/server.ts` to align with the new entry point structure.
* Updated the `bin` field to use `dist/index.js` instead of `dist/server.js` for the `mcp-server` binary.