### PR TITLE
Add README files to package.json files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
 		"gen:mcp": "orval --config ./orval.config.ts"
 	},
 	"files": [
-		"dist/**/*"
+		"dist/**/*",
+		"README*"
 	],
 	"msw": {
 		"workerDirectory": [


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change ensures that any `README` files are included in the package distribution by adding `"README*"` to the `files` array.