### PR TITLE
README: Add language links for English and Japanese versions

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,8 @@
 
 TouchDesignerのためのMCP(Model Context Protocol) サーバー実装です。AIエージェントがTouchDesignerプロジェクトを制御・操作できるようになることを目指しています。
 
+[English](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/README.md) / [日本語](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/README.ja.md)
+
 ## 概要
 
 ![demo](https://github.com/user-attachments/assets/333b7db8-ebcb-4ac2-812e-c2174fa4bb2b)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is an implementation of an MCP (Model Context Protocol) server for TouchDesigner. The goal is to enable AI agents to control and operate TouchDesigner projects.
 
+[English](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/README.md) / [日本語](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/README.ja.md)
+
 ## Overview
 
 ![demo](https://github.com/user-attachments/assets/333b7db8-ebcb-4ac2-812e-c2174fa4bb2b)


### PR DESCRIPTION
This pull request adds language navigation links to the `README` files, allowing users to switch between English and Japanese documentation more easily.

Documentation updates:

* [`README.ja.md`](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R5-R6): Added links to switch between the English and Japanese versions of the README.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R6): Added links to switch between the English and Japanese versions of the README.