### PR TITLE
update: add Windows drive letter instruction in README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -58,6 +58,8 @@ TouchDesignerが起動した状態で、AIエージェント（Claude Desktop,Cu
 }
 ```
 
+*Windows環境では C:\\ の様にドライブレターを含めてください [参考](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*
+
 MCPサーバーが認識されていればセットアップは完了です。
 起動時にエラーが表示される場合はTouchDesignerを先に起動してから再度エージェントを起動してください。
 TouchDesigner で APIサーバーが実行されていれば、エージェントは提供された TouchDesigner ツールを通じてTouchDesignerを使用できます。
@@ -169,6 +171,8 @@ TouchDesignerが起動した状態で、AIエージェント（Cursor, Claude De
   }
 }
 ```
+
+*Windows環境では C:\\ の様にドライブレターを含めてください [参考](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*
 
 ### セットアップ後のプロジェクト構造概要
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ With TouchDesigner running, configure your AI agent (Claude Desktop, Cursor, VSC
 }
 ```
 
+*On Windows system, please include the drive letter such as C: [Reference](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*.
+
 If the MCP server is recognized, setup is complete.
 If you see an error at startup, try launching the agent again after starting TouchDesigner.
 If the API server is running in TouchDesigner, the agent can use TouchDesigner via the provided tools.
@@ -170,6 +172,8 @@ With TouchDesigner running, configure your AI agent (Cursor, Claude Desktop, VSC
   }
 }
 ```
+
+*On Windows system, please include the drive letter such as C: [Reference](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*.
 
 ### Project Structure After Setup
 


### PR DESCRIPTION
This pull request updates the documentation in both `README.md` and `README.ja.md` to include a note for Windows users about specifying the drive letter in paths. The updates ensure consistency across the English and Japanese versions of the README files.

Documentation updates:

* [`README.ja.md`](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R61-R62): Added a note in two sections advising Windows users to include the drive letter (e.g., `C:\`) for paths, with a reference link for further details. [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R61-R62) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336R175-R176)
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R62): Added the same note in the corresponding sections of the English README file, ensuring parity with the Japanese version. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R61-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R176-R177)