### PR TITLE
update: refine Windows path instructions in README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ TouchDesignerが起動した状態で、AIエージェント（Claude Desktop,Cu
   "mcpServers": {
     "touchdesigner": {
       "args": [
-        "/path/to/your/touchdesigner-mcp-server/dist/index.js", // <-- touchdesigner-mcp-server/dist/index.js への絶対パスに置き換えてください
+        "/path/to/your/node_modules/touchdesigner-mcp-server/dist/index.js", // <-- node_modules/touchdesigner-mcp-server/dist/index.js への絶対パスに置き換えてください
         "--stdio"
       ],
       "command": "node",
@@ -58,9 +58,10 @@ TouchDesignerが起動した状態で、AIエージェント（Claude Desktop,Cu
 }
 ```
 
-*Windows環境では C:\\ の様にドライブレターを含めてください [参考](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*
+*Windows環境では C:\\ の様にドライブレターを含めてください。 例. `C:\\path\\to\\your\\node_modules\\touchdesigner-mcp-server\\dist\\index.js`*
 
 MCPサーバーが認識されていればセットアップは完了です。
+認識されない場合はAIエージェントを再起動するなどしてください。
 起動時にエラーが表示される場合はTouchDesignerを先に起動してから再度エージェントを起動してください。
 TouchDesigner で APIサーバーが実行されていれば、エージェントは提供された TouchDesigner ツールを通じてTouchDesignerを使用できます。
 
@@ -172,7 +173,7 @@ TouchDesignerが起動した状態で、AIエージェント（Cursor, Claude De
 }
 ```
 
-*Windows環境では C:\\ の様にドライブレターを含めてください [参考](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*
+*Windows環境では C:\\ の様にドライブレターを含めてください。 例. `C:\\path\\to\\your\\touchdesigner-mcp\\dist\\index.js`*
 
 ### セットアップ後のプロジェクト構造概要
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ With TouchDesigner running, configure your AI agent (Claude Desktop, Cursor, VSC
   "mcpServers": {
     "touchdesigner": {
       "args": [
-        "/path/to/your/touchdesigner-mcp-server/dist/index.js", // <-- Replace with the absolute path to touchdesigner-mcp-server/dist/index.js
+        "/path/to/your/node_modules/touchdesigner-mcp-server/dist/index.js", // <-- Replace with the absolute path to node_modules/touchdesigner-mcp-server/dist/index.js
         "--stdio"
       ],
       "command": "node",
@@ -58,9 +58,10 @@ With TouchDesigner running, configure your AI agent (Claude Desktop, Cursor, VSC
 }
 ```
 
-*On Windows system, please include the drive letter such as C: [Reference](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*.
+*On Windows system, please include the drive letter such as C: e.g. `C:\\path\\to\\your\\node_modules\\touchdesigner-mcp-server\\dist\\index.js`*
 
 If the MCP server is recognized, setup is complete.
+Restart the agent, if not recognized.
 If you see an error at startup, try launching the agent again after starting TouchDesigner.
 If the API server is running in TouchDesigner, the agent can use TouchDesigner via the provided tools.
 
@@ -173,7 +174,7 @@ With TouchDesigner running, configure your AI agent (Cursor, Claude Desktop, VSC
 }
 ```
 
-*On Windows system, please include the drive letter such as C: [Reference](https://github.com/modelcontextprotocol/servers/issues/40#issuecomment-2500235499)*.
+*On Windows system, please include the drive letter such as C: e.g. `C:\\path\\to\\your\\touchdesigner-mcp\\dist\\index.js`*
 
 ### Project Structure After Setup
 


### PR DESCRIPTION
This pull request updates the setup instructions for configuring the TouchDesigner MCP server in both Japanese (`README.ja.md`) and English (`README.md`) documentation. The changes clarify the file paths, improve Windows-specific instructions, and provide additional troubleshooting tips.

### Updates to file paths:
* Updated the example paths to reference `node_modules/touchdesigner-mcp-server/dist/index.js` instead of `touchdesigner-mcp-server/dist/index.js` to reflect a more common project structure. (`README.ja.md`: [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L51-R51) `README.md`: [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L51-R51)

### Improvements to Windows-specific instructions:
* Enhanced Windows instructions by including an example path with `C:\` and clarified the need to include the drive letter. (`README.ja.md`: [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L61-R64) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L175-R176); `README.md`: [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R64) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L176-R177)

### Troubleshooting tips:
* Added guidance to restart the AI agent if the MCP server is not recognized during setup. (`README.ja.md`: [[1]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L61-R64) `README.md`: [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L61-R64)