### PR TITLE
0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2025-06-21
+
+### Added
+- Added `CHANGELOG.md`
+
+### Changed
+- `get_td_nodes` now returns only a minimal overview of nodes by default to prevent information overload. Full properties can be included by setting the `includeProperties` parameter to `true`. ([#65](https://github.com/8beeeaaat/touchdesigner-mcp/pull/65))
+
+## [0.2.13] - 2025-05-24
+
+### Changed
+- Version maintenance updates
+- Updated API schema version references
+
+## [0.2.12] - 2025-05-24
+
+### Added
+- Comprehensive installation guide for AI agents (`llms-install.md`) ([#63](https://github.com/8beeeaaat/touchdesigner-mcp/pull/63))
+- Detailed setup instructions for Cline, Claude Desktop, Cursor, and Roo Code
+
+### Changed
+- Updated GitHub Actions workflow configuration
+- Restructured README.md content
+
+## [0.2.10] - 2025-05-XX
+
+### Added
+- Complete Docker containerization support ([#58](https://github.com/8beeeaaat/touchdesigner-mcp/pull/58))
+- Dockerfile and docker-compose.yml for easy deployment
+- Makefile for simplified build management
+- Environment variable management via dotenv configuration
+- Enhanced MCP server configuration management
+
+### Changed
+- Updated npm packages to latest versions
+- Improved README documentation with Docker setup instructions
+- Enhanced CI/CD workflows for Docker support
+
+### Fixed
+- Re-implemented and fixed Docker functionality (originally from 0.2.9)
+
+## [0.2.9] - 2025-05-XX
+
+### Added
+- Initial Docker image implementation for TouchDesigner MCP Server ([#54](https://github.com/8beeeaaat/touchdesigner-mcp/pull/54))
+
+### Note
+- This version was initially reverted ([#55](https://github.com/8beeeaaat/touchdesigner-mcp/pull/55)) due to issues, then fixed and re-implemented in 0.2.10
+
+## [0.2.8] - 2025-05-XX
+
+### Changed
+- Updated @types/node and vite packages ([#51](https://github.com/8beeeaaat/touchdesigner-mcp/pull/51))
+- Dependency maintenance updates
+
+## [0.2.7] - 2025-05-XX
+
+### Added
+- Tutorial images and text port images to README files ([#47](https://github.com/8beeeaaat/touchdesigner-mcp/pull/47))
+- Visual assets: `assets/textport.png` and `assets/tutorial.png`
+- Enhanced visual documentation for better user experience
+
+### Changed
+- Updated both English and Japanese README files with visual guides
+
+## [0.2.6] - 2025-05-XX
+
+### Fixed
+- Removed trailing period from REFERENCE_COMMENT constant for consistency ([#40](https://github.com/8beeeaaat/touchdesigner-mcp/pull/40))
+- Minor code formatting improvements
+
+## [0.2.5] - 2025-05-XX
+
+### Added
+- Safe data serialization with `safe_serialize` function ([#38](https://github.com/8beeeaaat/touchdesigner-mcp/pull/38))
+
+### Changed
+- Improved import formatting in Python API controller
+- Enhanced error handling and data serialization practices
+
+## [0.1.0] - 2025-XX-XX
+
+### Added
+- Initial implementation of TouchDesigner MCP Server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "0.2.13",
+	"version": "0.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "0.2.13",
+			"version": "0.3.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "0.2.13",
+	"version": "0.3.0",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/src/api/index.yml
+++ b/src/api/index.yml
@@ -1,12 +1,12 @@
 info:
   description: OpenAPI schema for generating TouchDesigner API client code
   title: TouchDesigner API
-  version: 0.2.13
+  version: 0.3.0
 
 openapi: 3.0.0
 
 servers:
-  - url: '{baseUrl}'
+  - url: "{baseUrl}"
     variables:
       baseUrl:
         default: http://localhost:9981

--- a/src/server/touchDesignerServer.ts
+++ b/src/server/touchDesignerServer.ts
@@ -25,7 +25,7 @@ export class TouchDesignerServer {
 		this.server = new McpServer(
 			{
 				name: "TouchDesigner",
-				version: "0.2.13",
+				version: "0.3.0",
 			},
 			{
 				capabilities: {


### PR DESCRIPTION
## [0.3.0] - 2025-06-21

### Added
- Added `CHANGELOG.md`

### Changed
- `get_td_nodes` now returns only a minimal overview of nodes by default to prevent information overload. Full properties can be included by setting the `includeProperties` parameter to `true`. ([#65](https://github.com/8beeeaaat/touchdesigner-mcp/pull/65))

https://github.com/user-attachments/assets/fd982a96-7213-416c-af3f-9b62d5938ae8
