### PR TITLE
Update server command and improve README instructions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
               "mcpServers": {
                 "touchdesigner": {
                   "command": "npx",
-                  "args": ["touchdesigner-mcp-server", "--stdio"]
+                  "args": ["touchdesigner-mcp-server@prerelease", "--stdio"]
                 }
               }
             }

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,11 +24,10 @@ TouchDesigner MCPは、AIモデルとTouchDesigner WebServer DAT 間のブリッ
 
 npxを使用する場合、TouchDesignerコンポーネントを別途ダウンロードする必要があります：
 1. [リリースページ](https://github.com/8beeeaaat/touchdesigner-mcp/releases)から `touchdesigner-mcp-td.zip` をダウンロード
-2. zipファイルを展開して `td` ディレクトリを取得
-3. 展開したファイルから `mcp_webserver_base.tox` を操作したいTouchDesignerプロジェクト直下にimportします。
+2. zipファイルを展開したフォルダから `mcp_webserver_base.tox` を操作したいTouchDesignerプロジェクト直下にimportします。
 例: `/project1/mcp_webserver_base` となるように配置
 
-**⚠️ 重要:** `td` ディレクトリの構造は展開した状態を正確に保持する必要があります。`mcp_webserver_base.tox` コンポーネントは `modules/` ディレクトリやその他のファイルへの相対パスを参照しています。展開した `td` ディレクトリ内のファイルを移動したり再編成したりしないでください。
+**⚠️ 重要:** ディレクトリの構造は展開した状態を正確に保持する必要があります。`mcp_webserver_base.tox` コンポーネントは `modules/` ディレクトリやその他のファイルへの相対パスを参照しています。展開したディレクトリ内のファイルを移動したり再編成したりしないでください。
 
 ##### 2. AIエージェントの設定：
 
@@ -39,7 +38,7 @@ npxを使用する場合、TouchDesignerコンポーネントを別途ダウン�
     "touchdesigner": {
       "command": "npx",
       "args": [
-        "touchdesigner-mcp-server",
+        "touchdesigner-mcp-server@prerelease",
         "--stdio"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ TouchDesigner MCP acts as a bridge between AI models and the TouchDesigner WebSe
 
 Since you're using npx, you'll need to download the TouchDesigner components separately:
 1. Download `touchdesigner-mcp-td.zip` from the [releases page](https://github.com/8beeeaaat/touchdesigner-mcp/releases)
-2. Extract the zip file to get the `td` directory
+2. Extract the zip file to get the directory
 3. Import `mcp_webserver_base.tox` from the extracted files directly under the TouchDesigner project you want to control.
 Example: Place it as `/project1/mcp_webserver_base`
 
-**⚠️ Important:** The `td` directory structure must be preserved exactly as extracted. The `mcp_webserver_base.tox` component references relative paths to the `modules/` directory and other files. Do not move or reorganize files within the extracted `td` directory.
+**⚠️ Important:** The directory structure must be preserved exactly as extracted. The `mcp_webserver_base.tox` component references relative paths to the `modules/` directory and other files. Do not move or reorganize files within the extracted directory.
 
 #### 2. Configure your AI agent:
 
@@ -39,7 +39,7 @@ Example: Place it as `/project1/mcp_webserver_base`
     "touchdesigner": {
       "command": "npx",
       "args": [
-        "touchdesigner-mcp-server",
+        "touchdesigner-mcp-server@prerelease",
         "--stdio"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
 		".": {
 			"import": "./dist/index.js",
 			"types": "./dist/index.d.ts"
+		},
+		"./cli": {
+			"import": "./dist/cli.js",
+			"types": "./dist/cli.d.ts"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
This pull request introduces updates to the `touchdesigner-mcp-server` configuration, documentation improvements, and new CLI entry points in `package.json`. The most significant changes involve switching to the prerelease version of the MCP server, refining the documentation for clarity, and adding CLI-specific exports to the package configuration.

### Configuration Updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L100-R100): Updated `touchdesigner-mcp-server` arguments to use the prerelease version (`touchdesigner-mcp-server@prerelease`) for improved compatibility.
* `README.md` and `README.ja.md`: Updated example configurations to reflect the use of the prerelease version of `touchdesigner-mcp-server` in the `args` field. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R42) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L42-R41)

### Documentation Improvements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R31): Simplified and clarified instructions for extracting and preserving the directory structure. Removed references to the `td` directory name to make the instructions more generic.
* [`README.ja.md`](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L27-R30): Improved Japanese documentation by simplifying extraction instructions and removing redundant references to the directory name.

### Package Configuration:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R54-R57): Added CLI-specific exports (`./cli`) for both import and types, enabling better support for CLI tools.Update the server command to utilize the prerelease version of the TouchDesigner MCP server and enhance the README with clearer instructions for downloading and importing components.