### PR TITLE
Release 0.4.0-alpha.6

### DIFF
--- a/.dxtignore
+++ b/.dxtignore
@@ -1,0 +1,7 @@
+**/*.test.*
+*.log
+.claude/
+.github/
+td/
+tests/
+node_modules/

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -31,3 +31,14 @@ jobs:
       - run: npm run gen
       - run: npm run lint
       - run: npm run test:unit
+      - name: Test DXT package build
+        run: |
+          # Install DXT CLI tool
+          npm install -g @anthropic-ai/dxt
+          
+          # Build DXT package to ensure it works
+          npm run build:dist
+          npm run build:dxt
+          
+          echo "DXT package build test completed!"
+          ls -la *.dxt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# This workflow builds the project, creates packages, and publishes a release.
+# It triggers on pushes to the main branch and on tags that start with 'v'.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Release CI
@@ -10,7 +11,7 @@ on:
   push:
     branches: ["main"]
     tags:
-      - "v*"  # v で始まるタグにも対応
+      - "v*"  # Also triggered by tags starting with 'v'
 
 jobs:
   build:
@@ -41,8 +42,8 @@ jobs:
           docker cp temp-mcp:/app/dist ./
           docker rm temp-mcp
 
-          # Create selective td directory package
-          echo "Creating selective td directory package..."
+          # Create a package for the td directory
+          echo "Creating td directory package..."
           mkdir -p temp_td
           cp td/import_modules.py temp_td/
           cp td/mcp_webserver_base.tox temp_td/
@@ -50,7 +51,17 @@ jobs:
           cd temp_td && zip -r ../touchdesigner-mcp-td.zip .
           rm -rf temp_td
           echo "Build artifacts extracted and package created!"
-      - name: nodejs project information
+      - name: Build DXT package
+        run: |
+          # Install DXT CLI tool
+          npm install -g @anthropic-ai/dxt
+
+          # Build DXT package
+          npx @anthropic-ai/dxt pack
+
+          echo "DXT package created successfully!"
+          ls -la *.dxt
+      - name: Get Node.js project information
         id: projectinfo
         uses: gregoranders/nodejs-project-info@master
       - name: Determine if prerelease
@@ -78,20 +89,29 @@ jobs:
           name: ${{ steps.projectinfo.outputs.name }} - ${{ steps.projectinfo.outputs.version }} Release
           body: |
             ## Downloads
-            - **TouchDesigner Components (Complete)**: [touchdesigner-mcp-td.zip](https://github.com/${{ github.repository }}/releases/download/v${{ steps.projectinfo.outputs.version }}/touchdesigner-mcp-td.zip)
-            - **npm package**: `npx -y touchdesigner-mcp-server@prerelease --stdio`
+            - **TouchDesigner Components**: [touchdesigner-mcp-td.zip](https://github.com/${{ github.repository }}/releases/download/v${{ steps.projectinfo.outputs.version }}/touchdesigner-mcp-td.zip)
+            - **Desktop Extension (.dxt)**: [touchdesigner-mcp.dxt](https://github.com/${{ github.repository }}/releases/download/v${{ steps.projectinfo.outputs.version }}/touchdesigner-mcp.dxt)
 
             ## Usage
 
-            ### Quick Start with npx
-            1. Download and extract the TouchDesigner components from `touchdesigner-mcp-td.zip`
-            2. Import `mcp_webserver_base.tox` into your TouchDesigner project
-            3. Run the MCP server:
-            ```bash
-            npx -y touchdesigner-mcp-server@prerelease --stdio
-            ```
+            ### Quick Start with Claude Desktop and Desktop Extension (Recommended)
+            1. Download `TouchDesigner Components` and the `Desktop Extension`.
+            2. Extract the TouchDesigner components from `touchdesigner-mcp-td.zip`.
+            3. Import `mcp_webserver_base.tox` into your TouchDesigner project.
 
-            ### Claude Desktop Configuration
+            https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
+
+            4. Install the extension in Claude Desktop by double-clicking the `touchdesigner-mcp.dxt` file.
+
+            https://github.com/user-attachments/assets/0786d244-8b82-4387-bbe4-9da048212854
+
+            5. The extension will automatically handle the TouchDesigner server connection.
+
+            ### Set up with npx
+            1. Download and extract the TouchDesigner components from `touchdesigner-mcp-td.zip`.
+            2. Import `mcp_webserver_base.tox` into your TouchDesigner project.
+            3. Set up the MCP Server configuration:
+
             ```json
             {
               "mcpServers": {
@@ -104,8 +124,9 @@ jobs:
             ```
 
             ## Changes
-            See the full changelog at https://github.com/${{ github.repository }}/releases
+            See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for a detailed history of changes.
           files: |
+            touchdesigner-mcp.dxt
             touchdesigner-mcp-td.zip
           draft: false
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}
@@ -127,10 +148,10 @@ jobs:
       - name: Publish to npm
         run: |
           if [[ "${{ needs.build.outputs.is_prerelease }}" == "true" ]]; then
-            echo "Publishing prerelease version with prerelease tag..."
+            echo "Publishing prerelease version with 'prerelease' tag..."
             npm publish --access public --tag prerelease
           else
-            echo "Publishing production version with latest tag..."
+            echo "Publishing production version with 'latest' tag..."
             npm publish --access public
           fi
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,8 @@ src/gen
 .github/copilot-instructions.md
 .venv
 .actrc
+*.dxt
+*.pem
 td/modules/td_server
 
 # coding agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0-alpha.6] - 2025-06-29
+
+### Added
+- **Desktop Extension (.dxt) Support**: Added full Desktop Extension (DXT) package support for Claude Desktop ([#82](https://github.com/8beeeaaat/touchdesigner-mcp/pull/82))
+- New `manifest.json` file defining DXT package configuration with tools, prompts, and user configuration options
+- User-configurable TouchDesigner port setting via DXT user interface
+- Comprehensive tool definitions and descriptions in DXT manifest
+- New `.dxtignore` file to exclude unnecessary files from DXT package
+
+### Changed
+- **GitHub Actions Workflow**: Enhanced release workflow to build and publish DXT packages automatically
+  - Added DXT CLI tool installation and package building steps
+  - Updated release body to include video demonstration links for setup instructions
+- **README Updates**: Added visual demonstration links and improved installation instructions
+  - Added GitHub user-attachments video links for TouchDesigner setup and DXT installation
+  - Enhanced documentation for all installation methods (DXT, npx, Docker)
+  - Updated both English and Japanese README files with video guides
+- **gitignore**: Added DXT-related ignore patterns
+
+### Documentation
+- Enhanced installation documentation with visual guides and video demonstrations
+- Improved DXT package distribution documentation
+- Added comprehensive tool and prompt descriptions in DXT manifest
+
+### Technical
+- Version bumped to 0.4.0-alpha.6 across all relevant files
+- DXT package workflow integrated into CI/CD pipeline
+- Maintained backward compatibility with existing installation methods
+
 ## [0.4.0-alpha.5] - 2025-06-29
 
 ### Changed

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,20 +16,52 @@ TouchDesigner MCPは、AIモデルとTouchDesigner WebServer DAT 間のブリッ
 ## 利用方法
 
 <details>
-  <summary>方法1: npx を利用する（クイックスタート）</summary>
+  <summary>方法1: Claude Desktop + Desktop Extensions（推奨）</summary>
+
+##### 1. ファイルをダウンロード：
+[リリースページ](https://github.com/8beeeaaat/touchdesigner-mcp/releases)から以下をダウンロード：
+- **TouchDesigner Components**: `touchdesigner-mcp-td.zip`
+- **Desktop Extensions (.dxt)**: `touchdesigner-mcp.dxt`
+
+##### 2. TouchDesignerコンポーネントを設置：
+1. `touchdesigner-mcp-td.zip`を展開
+2. 展開したフォルダから`mcp_webserver_base.tox`を操作したいTouchDesignerプロジェクト直下にインポート
+   例: `/project1/mcp_webserver_base`となるように配置
+
+https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
+
+  TouchDesignerのメニューからTextportを起動してサーバーの起動ログを確認できます。
+
+  ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
+
+##### 3. Desktop Extensionをインストール：
+`touchdesigner-mcp.dxt`ファイルをダブルクリックしてClaude Desktopに拡張機能をインストール
+
+https://github.com/user-attachments/assets/0786d244-8b82-4387-bbe4-9da048212854
+
+##### 4. 拡張機能が自動的にTouchDesignerサーバー接続を処理
+
+**⚠️ 重要:** TouchDesignerコンポーネントのディレクトリ構造は展開した状態を正確に保持してください。`mcp_webserver_base.tox`コンポーネントは`modules/`ディレクトリやその他のファイルへの相対パスを参照しています。
+
+</details>
+
+<details>
+  <summary>方法2: npxを利用する</summary>
 
 *Node.jsがインストールされていることが前提となります*
 
-##### 1. TouchDesigner プロジェクトにMCP連携用のAPIサーバーを設置
+##### 1. TouchDesignerコンポーネントを設置：
+1. [リリースページ](https://github.com/8beeeaaat/touchdesigner-mcp/releases)から`touchdesigner-mcp-td.zip`をダウンロード
+2. zipファイルを展開し、`mcp_webserver_base.tox`を操作したいTouchDesignerプロジェクト直下にインポート
+   例: `/project1/mcp_webserver_base`となるように配置
 
-npxを使用する場合、TouchDesignerコンポーネントを別途ダウンロードする必要があります：
-1. [リリースページ](https://github.com/8beeeaaat/touchdesigner-mcp/releases)から `touchdesigner-mcp-td.zip` をダウンロード
-2. zipファイルを展開したフォルダから `mcp_webserver_base.tox` を操作したいTouchDesignerプロジェクト直下にimportします。
-例: `/project1/mcp_webserver_base` となるように配置
+https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
 
-**⚠️ 重要:** ディレクトリの構造は展開した状態を正確に保持する必要があります。`mcp_webserver_base.tox` コンポーネントは `modules/` ディレクトリやその他のファイルへの相対パスを参照しています。展開したディレクトリ内のファイルを移動したり再編成したりしないでください。
+  TouchDesignerのメニューからTextportを起動してサーバーの起動ログを確認できます。
 
-##### 2. AIエージェントの設定：
+  ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
+
+##### 2. MCPサーバー設定：
 
 *例 Claude Desktop*
 ```json
@@ -37,17 +69,13 @@ npxを使用する場合、TouchDesignerコンポーネントを別途ダウン�
   "mcpServers": {
     "touchdesigner": {
       "command": "npx",
-      "args": [
-        "-y",
-        "touchdesigner-mcp-server@prerelease",
-        "--stdio"
-      ]
+      "args": ["-y", "touchdesigner-mcp-server@prerelease", "--stdio"]
     }
   }
 }
 ```
 
-**TIPS：** `--host`と`--port`引数を追加することで、TouchDesignerサーバー接続をカスタマイズできます：
+**カスタマイズ：** `--host`と`--port`引数を追加してTouchDesignerサーバー接続をカスタマイズできます：
 ```json
 "args": [
   "-y",
@@ -60,7 +88,7 @@ npxを使用する場合、TouchDesignerコンポーネントを別途ダウン�
 </details>
 
 <details>
-  <summary>方法2: Dockerイメージを利用</summary>
+  <summary>方法3: Dockerイメージを利用</summary>
 
 [![tutorial](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/tutorial_docker.png)](https://www.youtube.com/watch?v=BRWoIEVb0TU)
 
@@ -77,26 +105,26 @@ cd touchdesigner-mcp
 make build
 ```
 
-##### 3. TouchDesigner プロジェクトにMCP連携用のAPIサーバーを設置
+##### 3. TouchDesignerプロジェクトにMCP連携用のAPIサーバーを設置
 
-TouchDesignerを起動し、`td/mcp_webserver_base.tox` コンポーネントを操作したいTouchDesignerプロジェクト直下にimportします。
-例: `/project1/mcp_webserver_base` となるように配置
+TouchDesignerを起動し、`td/mcp_webserver_base.tox`コンポーネントを操作したいTouchDesignerプロジェクト直下にインポートします。  
+例: `/project1/mcp_webserver_base`となるように配置
 
-tox のimport により `td/import_modules.py` スクリプトが動作し、APIサーバのコントローラなどのモジュールがロードされます。
+toxファイルのインポートにより`td/import_modules.py`スクリプトが実行され、APIサーバーのコントローラなどのモジュールがロードされます。
 
-![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/import.png)
+https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
 
-TouchDesigner のメニューから Textportを起動してサーバーの起動ログを確認することができます。
+TouchDesignerのメニューからTextportを起動してサーバーの起動ログを確認できます。
 
 ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
 
-#### 4. MCPサーバーのコンテナを起動
+##### 4. MCPサーバーのコンテナを起動
 
 ```bash
 docker-compose up -d
 ```
 
-##### 5. AIエージェントがDockerコンテナを使用するように設定して起動：
+##### 5. AIエージェントがDockerコンテナを使用するように設定：
 
 *例 Claude Desktop*
 ```json
@@ -123,7 +151,7 @@ docker-compose up -d
 
 *Windows システムでは、ドライブレターを含めてください。例：`C:\\path\\to\\your\\touchdesigner-mcp\\docker-compose.yml`*
 
-**TIPS：** `--port`引数を追加することで、TouchDesignerサーバー接続をカスタマイズできます：
+**カスタマイズ：** `--port`引数を追加してTouchDesignerサーバー接続をカスタマイズできます：
   ```json
 "args": [
   ...,
@@ -137,10 +165,10 @@ docker-compose up -d
 
 ## 接続確認
 
-MCPサーバーが認識されていればセットアップは完了です。
-認識されない場合はAIエージェントを再起動するなどしてください。
-起動時にエラーが表示される場合はTouchDesignerを先に起動してから再度エージェントを起動してください。
-TouchDesigner で APIサーバーが実行されていれば、エージェントは提供された ツール等を通じてTouchDesignerを使用できます。
+MCPサーバーが認識されていればセットアップは完了です。  
+認識されない場合は、AIエージェントを再起動してください。  
+起動時にエラーが表示される場合は、TouchDesignerを先に起動してからAIエージェントを再度起動してください。  
+TouchDesignerでAPIサーバーが実行されていれば、エージェントは提供されたツール等を通じてTouchDesignerを使用できます。
 
 ### ディレクトリ構造要件
 
@@ -172,7 +200,7 @@ td/
 | :-------------------------- | :--------------------------------------------- |
 | `create_td_node`            | 新しいノードを作成します。                     |
 | `delete_td_node`            | 既存のノードを削除します。                     |
-| `exec_node_method`| ノードに対しPythonメソッドを呼び出します。       |
+| `exec_node_method`          | ノードに対してPythonメソッドを呼び出します。   |
 | `execute_python_script`     | TD内で任意のPythonスクリプトを実行します。     |
 | `get_td_class_details`      | TD Pythonクラス/モジュールの詳細情報を取得します。 |
 | `get_td_classes`            | TouchDesigner Pythonクラスのリストを取得します。 |
@@ -217,7 +245,7 @@ td/
 
 3. **利用可能なコマンド:**
    ```bash
-   npm run test      # ユニットテストと結合テストを実行
+   npm run test      # ユニットテストと統合テストを実行
    npm run dev       # デバッグ用MCPインスペクターを起動
    ```
 
@@ -226,9 +254,9 @@ td/
 ### プロジェクト構造の概要
 
 ```
-├── src/                       # MCPサーバー ソースコード
+├── src/                       # MCPサーバーソースコード
 │   ├── api/                  # TD WebServerに対するOpenAPI仕様
-│   ├── core/                 # コアユーティリティ (ロガー, エラーハンドリング)
+│   ├── core/                 # コアユーティリティ（ロガー、エラーハンドリング）
 │   ├── features/             # MCP機能実装
 │   │   ├── prompts/         # プロンプトハンドラ
 │   │   ├── resources/       # リソースハンドラ

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TouchDesigner MCP
 
-This is an implementation of an MCP (Model Context Protocol) server for TouchDesigner. The goal is to enable AI agents to control and operate TouchDesigner projects.
+This is an implementation of an MCP (Model Context Protocol) server for TouchDesigner. Its goal is to enable AI agents to control and operate TouchDesigner projects.
 
 [English](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/README.md) / [日本語](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/README.ja.md)
 
@@ -16,39 +16,67 @@ TouchDesigner MCP acts as a bridge between AI models and the TouchDesigner WebSe
 ## Usage
 
 <details>
-  <summary>Method 1: Using npx (Quick Start)</summary>
+  <summary>Method 1: Using Claude Desktop and Desktop Extensions (Recommended)</summary>
 
-*Requires Node.js to be installed*
+### 1. Download Files
+Download the following from the [releases page](https://github.com/8beeeaaat/touchdesigner-mcp/releases):
+- **TouchDesigner Components**: `touchdesigner-mcp-td.zip`
+- **Desktop Extension (.dxt)**: `touchdesigner-mcp.dxt`
 
-#### 1. Install the API Server in Your TouchDesigner Project:
+### 2. Set up TouchDesigner Components
+1. Extract the TouchDesigner components from `touchdesigner-mcp-td.zip`.
+2. Import `mcp_webserver_base.tox` into your TouchDesigner project.
+3. Place it at `/project1/mcp_webserver_base`.
 
-Since you're using npx, you'll need to download the TouchDesigner components separately:
-1. Download `touchdesigner-mcp-td.zip` from the [releases page](https://github.com/8beeeaaat/touchdesigner-mcp/releases)
-2. Extract the zip file to get the directory
-3. Import `mcp_webserver_base.tox` from the extracted files directly under the TouchDesigner project you want to control.
-Example: Place it as `/project1/mcp_webserver_base`
+https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
 
-**⚠️ Important:** The directory structure must be preserved exactly as extracted. The `mcp_webserver_base.tox` component references relative paths to the `modules/` directory and other files. Do not move or reorganize files within the extracted directory.
+  You can check the startup logs by opening the Textport from the TouchDesigner menu.
 
-#### 2. Configure your AI agent:
+  ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
 
-*Example for Claude Desktop*
+### 3. Install the Desktop Extension
+Double-click the `touchdesigner-mcp.dxt` file to install the extension in Claude Desktop.
+
+https://github.com/user-attachments/assets/0786d244-8b82-4387-bbe4-9da048212854
+
+### 4. Connect to the Server
+The extension will automatically handle the connection to the TouchDesigner server.
+
+**⚠️ Important:** The directory structure must be preserved exactly as extracted. The `mcp_webserver_base.tox` component references relative paths to the `modules/` directory and other files.
+
+</details>
+
+<details>
+  <summary>Method 2: Using npx</summary>
+
+*Requires Node.js to be installed.*
+
+### 1. Set up TouchDesigner Components
+1. Download and extract the TouchDesigner components from `touchdesigner-mcp-td.zip` ([releases page](https://github.com/8beeeaaat/touchdesigner-mcp/releases)).
+2. Import `mcp_webserver_base.tox` into your TouchDesigner project.
+3. Place it at `/project1/mcp_webserver_base`.
+
+https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
+
+  You can check the startup logs by opening the Textport from the TouchDesigner menu.
+
+  ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
+
+### 2. Set up the MCP Server Configuration
+
+*Example for Claude Desktop:*
 ```json
 {
   "mcpServers": {
     "touchdesigner": {
       "command": "npx",
-      "args": [
-        "-y",
-        "touchdesigner-mcp-server@prerelease",
-        "--stdio"
-      ]
+      "args": ["-y", "touchdesigner-mcp-server@prerelease", "--stdio"]
     }
   }
 }
 ```
 
-**Note:** You can customize the TouchDesigner server connection by adding `--host` and `--port` arguments:
+**Customization:** You can customize the TouchDesigner server connection by adding `--host` and `--port` arguments:
 ```json
 "args": [
   "-y",
@@ -61,45 +89,43 @@ Example: Place it as `/project1/mcp_webserver_base`
 </details>
 
 <details>
-  <summary>Method 2: Using Docker Image</summary>
+  <summary>Method 3: Using a Docker Image</summary>
 
   [![tutorial](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/tutorial_docker.png)](https://www.youtube.com/watch?v=BRWoIEVb0TU)
 
-  #### 1. Clone the repository:
+  ### 1. Clone the repository
   ```bash
   git clone https://github.com/8beeeaaat/touchdesigner-mcp.git
   cd touchdesigner-mcp
   ```
 
-  #### 2. Build the Docker image:
+  ### 2. Build the Docker image
   ```bash
-  git clone https://github.com/8beeeaaat/touchdesigner-mcp.git
-  cd touchdesigner-mcp
   make build
   ```
 
-  #### 3. Install the API Server in Your TouchDesigner Project:
+  ### 3. Install the API Server in Your TouchDesigner Project
 
-  Start TouchDesigner and import the `td/mcp_webserver_base.tox` component directly under the TouchDesigner project you want to control.
-  Example: Place it as `/project1/mcp_webserver_base`
+  Start TouchDesigner and import the `td/mcp_webserver_base.tox` component into the project you want to control.
+  Example: Place it at `/project1/mcp_webserver_base`.
 
-  Importing the tox will trigger the `td/import_modules.py` script, which loads modules such as API server controllers.
+  Importing the `.tox` file will trigger the `td/import_modules.py` script, which loads the necessary modules for the API server.
 
-  ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/import.png)
+https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
 
-  You can check boot logs by opening the Textport from the TouchDesigner menu.
+  You can check the startup logs by opening the Textport from the TouchDesigner menu.
 
   ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
 
-  #### 4. Start the MCP server container with your TouchDesigner configuration
+  ### 4. Start the MCP server container
 
   ```bash
   docker-compose up -d
   ```
 
-  #### 5. Configure your AI agent to use the Docker container:
+  ### 5. Configure your AI agent to use the Docker container
 
-  *Example for Claude Desktop*
+  *Example for Claude Desktop:*
   ```json
   {
     "mcpServers": {
@@ -120,9 +146,9 @@ Example: Place it as `/project1/mcp_webserver_base`
       }
     }
   }
-  ```
+```
 
-  *On Windows systems, include the drive letter like C: e.g. `C:\\path\\to\\your\\touchdesigner-mcp\\docker-compose.yml`*
+  *On Windows systems, include the drive letter, e.g., `C:\path\to\your\touchdesigner-mcp\docker-compose.yml`.*
 
 **Note:** You can customize the TouchDesigner server connection by adding `--host` and `--port` arguments:
   ```json
@@ -138,14 +164,14 @@ Example: Place it as `/project1/mcp_webserver_base`
 
 ## Verify Connection
 
-If the MCP server is recognized, setup is complete.
+If the MCP server is recognized, the setup is complete.
 If it's not recognized, try restarting your AI agent.
-If you see an error at startup, try launching the agent again after starting TouchDesigner first.
-When the API server is running properly in TouchDesigner, the agent can use the provided tools to operate TouchDesigner.
+If you see an error at startup, try launching the agent again after starting TouchDesigner.
+When the API server is running properly in TouchDesigner, the agent can use the provided tools to operate it.
 
 ### Directory Structure Requirements
 
-**Critical:** When using any method (Docker, npx), maintain the exact directory structure:
+**Critical:** When using any method, you must maintain the original directory structure:
 
 ```
 td/
@@ -164,7 +190,7 @@ The `mcp_webserver_base.tox` component uses relative paths to locate Python modu
 
 ## MCP Server Features
 
-This server enables operations on TouchDesigner via the Model Context Protocol (MCP) and provides references to various implementation documents.
+This server enables AI agents to perform operations in TouchDesigner using the Model Context Protocol (MCP).
 
 ### Tools
 
@@ -172,16 +198,16 @@ Tools allow AI agents to perform actions in TouchDesigner.
 
 | Tool Name                | Description                                                        |
 | :---------------------- | :----------------------------------------------------------------- |
-| `create_td_node`        | Create a new node.                                                 |
-| `delete_td_node`        | Delete an existing node.                                           |
-| `exec_node_method`      | Call a Python method on a node.                                    |
-| `execute_python_script` | Execute an arbitrary Python script in TD.                          |
-| `get_td_class_details`  | Get details of a TD Python class/module.                           |
-| `get_td_classes`        | Get a list of TouchDesigner Python classes.                        |
-| `get_td_info`           | Get information about the TD server environment.                   |
-| `get_td_node_parameters`| Get parameters of a specific node.                                 |
-| `get_td_nodes`          | Get nodes under a parent path (optionally filtered).               |
-| `update_td_node_parameters` | Update parameters of a specific node.                        |
+| `create_td_node`        | Creates a new node.                                                |
+| `delete_td_node`        | Deletes an existing node.                                          |
+| `exec_node_method`      | Calls a Python method on a node.                                   |
+| `execute_python_script` | Executes an arbitrary Python script in TouchDesigner.              |
+| `get_td_class_details`  | Gets details of a TouchDesigner Python class or module.            |
+| `get_td_classes`        | Gets a list of TouchDesigner Python classes.                       |
+| `get_td_info`           | Gets information about the TouchDesigner server environment.       |
+| `get_td_node_parameters`| Gets the parameters of a specific node.                            |
+| `get_td_nodes`          | Gets nodes under a parent path, with optional filtering.           |
+| `update_td_node_parameters` | Updates the parameters of a specific node.                     |
 
 ### Prompts
 
@@ -189,20 +215,20 @@ Prompts provide instructions for AI agents to perform specific actions in TouchD
 
 | Prompt Name         | Description                                                                 |
 | :------------------| :-------------------------------------------------------------------------- |
-| `Search node`      | Fuzzy search for nodes and retrieve information based on name, family, type. |
-| `Node connection`  | Provide instructions to connect nodes within TouchDesigner.                 |
-| `Check node errors`| Check errors for a specified node, recursively for child nodes if any.      |
+| `Search node`      | Fuzzy searches for nodes and retrieves information based on name, family, or type. |
+| `Node connection`  | Provides instructions to connect nodes within TouchDesigner.                |
+| `Check node errors`| Checks for errors on a specified node, and recursively for its children.    |
 
 ### Resources
 
-Not implemented
+Not implemented.
 
 
 ## For Developers
 
 ### Quick Start for Development
 
-1. **Setup environment:**
+1. **Set up your environment:**
    ```bash
    # Clone and install dependencies
    git clone https://github.com/8beeeaaat/touchdesigner-mcp.git
@@ -220,61 +246,61 @@ Not implemented
 3. **Available commands:**
    ```bash
    npm run test      # Run unit and integration tests
-   npm run dev       # Launch MCP inspector for debugging
+   npm run dev       # Launch the MCP inspector for debugging
    ```
 
-**Note:** When you update the code, restart both the MCP server and TouchDesigner to reflect changes.
+**Note:** When you update the code, you must restart both the MCP server and TouchDesigner to apply the changes.
 
 ### Project Structure Overview
 
 ```
 ├── src/                       # MCP server source code
-│   ├── api/                  # OpenAPI spec for TD WebServer
+│   ├── api/                  # OpenAPI spec for the TouchDesigner WebServer
 │   ├── core/                 # Core utilities (logger, error handling)
 │   ├── features/             # MCP feature implementations
 │   │   ├── prompts/         # Prompt handlers
 │   │   ├── resources/       # Resource handlers
 │   │   └── tools/           # Tool handlers (e.g., tdTools.ts)
-│   ├── gen/                  # Code generated from OpenAPI schema for MCP server
+│   ├── gen/                  # Code generated from the OpenAPI schema for the MCP server
 │   ├── server/               # MCP server logic (connections, main server class)
-│   ├── tdClient/             # TD connection API client
-│   ├── index.ts              # Main entry point for Node.js server
+│   ├── tdClient/             # TouchDesigner connection API client
+│   ├── index.ts              # Main entry point for the Node.js server
 │   └── ...
-├── td/                        # TouchDesigner related files
+├── td/                        # TouchDesigner-related files
 │   ├── modules/              # Python modules for TouchDesigner
-│   │   ├── mcp/              # Core logic for handling MCP requests in TD
+│   │   ├── mcp/              # Core logic for handling MCP requests in TouchDesigner
 │   │   │   ├── controllers/ # API request controllers (api_controller.py, generated_handlers.py)
 │   │   │   └── services/    # Business logic (api_service.py)
-│   │   ├── td_server/        # Python model code generated from OpenAPI schema
+│   │   ├── td_server/        # Python model code generated from the OpenAPI schema
 │   │   └── utils/            # Shared Python utilities
 │   ├── templates/             # Mustache templates for Python code generation
 │   ├── genHandlers.js         # Node.js script for generating generated_handlers.py
-│   ├── import_modules.py      # Helper script to import API server modules into TD
+│   ├── import_modules.py      # Helper script to import API server modules into TouchDesigner
 │   └── mcp_webserver_base.tox # Main TouchDesigner component
 ├── tests/                      # Test code
 │   ├── integration/
 │   └── unit/
-└── orval.config.ts             # Orval config (TS client generation)
+└── orval.config.ts             # Orval config (TypeScript client generation)
 ```
 
 
 ### API Code Generation Workflow
 
-This project uses OpenAPI-based code generation tools (Orval / openapi-generator-cli):
+This project uses OpenAPI-based code generation tools (Orval and openapi-generator-cli).
 
 **API Definition:** The API contract between the Node.js MCP server and the Python server running inside TouchDesigner is defined in `src/api/index.yml`.
 
 1.  **Python server generation (`npm run gen:webserver`):**
     *   Uses `openapi-generator-cli` via Docker.
     *   Reads `src/api/index.yml`.
-    *   Generates a Python server skeleton (`td/modules/td_server/`) based on the API definition. This code runs inside TouchDesigner via WebServer DAT.
+    *   Generates a Python server skeleton (`td/modules/td_server/`) based on the API definition. This code runs inside TouchDesigner's WebServer DAT.
     *   **Requires Docker to be installed and running.**
 2.  **Python handler generation (`npm run gen:handlers`):**
     *   Uses a custom Node.js script (`td/genHandlers.js`) and Mustache templates (`td/templates/`).
     *   Reads the generated Python server code or OpenAPI spec.
-    *   Generates handler implementations (`td/modules/mcp/controllers/generated_handlers.py`) that connect to business logic in `td/modules/mcp/services/api_service.py`.
+    *   Generates handler implementations (`td/modules/mcp/controllers/generated_handlers.py`) that connect to the business logic in `td/modules/mcp/services/api_service.py`.
 3.  **TypeScript client generation (`npm run gen:mcp`):**
-    *   Uses `Orval` to generate API client code and Zod schemas for tool validation from the schema YAML bundled by `openapi-generator-cli`.
+    *   Uses `Orval` to generate an API client and Zod schemas for tool validation from the schema YAML, which is bundled by `openapi-generator-cli`.
     *   Generates a typed TypeScript client (`src/tdClient/`) used by the Node.js server to make requests to the WebServer DAT.
 
 The build process (`npm run build`) runs all necessary generation steps (`npm run gen`), followed by TypeScript compilation (`tsc`).
@@ -283,13 +309,13 @@ The build process (`npm run build`) runs all necessary generation steps (`npm ru
 
 We welcome your contributions!
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Add tests and ensure everything works (`npm test`)
-5. Commit your changes (`git commit -m 'Add some amazing feature'`)
-6. Push to your branch (`git push origin feature/amazing-feature`)
-7. Open a pull request
+1. Fork the repository.
+2. Create a feature branch (`git checkout -b feature/amazing-feature`).
+3. Make your changes.
+4. Add tests and ensure everything works (`npm test`).
+5. Commit your changes (`git commit -m 'Add some amazing feature'`).
+6. Push to your branch (`git push origin feature/amazing-feature`).
+7. Open a pull request.
 
 Please always include appropriate tests when making implementation changes.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,115 @@
+{
+  "dxt_version": "0.1",
+  "name": "touchdesigner-mcp",
+  "version": "0.1.0",
+  "display_name": "TouchDesigner MCP Server",
+  "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
+  "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",
+  "author": {
+    "name": "8beeeaaat",
+    "url": "https://github.com/8beeeaaat/touchdesigner-mcp"
+  },
+  "server": {
+    "type": "node",
+    "entry_point": "dist/cli.js",
+    "mcp_config": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "touchdesigner-mcp-server@prerelease",
+        "--stdio",
+        "--port=${user_config.TD_WEB_SERVER_PORT}"
+      ],
+      "capabilities": {
+        "prompts": {},
+        "tools": {}
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "create_td_node",
+      "description": "Create new nodes in TouchDesigner with specified family and parameters"
+    },
+    {
+      "name": "delete_td_node",
+      "description": "Delete existing nodes from TouchDesigner by path"
+    },
+    {
+      "name": "execute_python_script",
+      "description": "Execute Python scripts directly in TouchDesigner environment with full API access"
+    },
+    {
+      "name": "exec_node_method",
+      "description": "Execute methods on TouchDesigner nodes (cook, pulse, reset, etc.)"
+    },
+    {
+      "name": "get_td_info",
+      "description": "Get TouchDesigner server information and connection status"
+    },
+    {
+      "name": "get_td_class_details",
+      "description": "Get detailed documentation for TouchDesigner Python classes"
+    },
+    {
+      "name": "get_td_classes",
+      "description": "List available TouchDesigner Python classes and modules"
+    },
+    {
+      "name": "get_td_node_parameters",
+      "description": "Retrieve parameters and current values for TouchDesigner nodes"
+    },
+    {
+      "name": "get_td_nodes",
+      "description": "List nodes in TouchDesigner with filtering options"
+    },
+    {
+      "name": "update_td_node_parameters",
+      "description": "Update parameter values for TouchDesigner nodes"
+    }
+  ],
+  "prompts": [
+    {
+      "name": "Search node",
+      "description": "Find TouchDesigner nodes by various criteria",
+      "text": "Search for TouchDesigner nodes using filters like name, family type, or parent path."
+    },
+    {
+      "name": "Check node errors",
+      "description": "Analyze and diagnose TouchDesigner node errors",
+      "text": "Analyze the current TouchDesigner project for node errors and provide debugging suggestions."
+    },
+    {
+      "name": "Node connection",
+      "description": "Guide for connecting TouchDesigner nodes properly",
+      "text": "Provide guidance on how to properly connect TouchDesigner nodes for optimal data flow."
+    }
+  ],
+  "user_config": {
+    "TD_WEB_SERVER_PORT": {
+      "title": "TouchDesigner Port",
+      "description": "Port number for TouchDesigner WebServer",
+      "type": "number",
+      "default": 9981,
+      "required": false
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "win32",
+      "darwin",
+      "linux"
+    ],
+    "node_version": ">=18.0.0"
+  },
+  "keywords": [
+    "touchdesigner",
+    "creative-coding",
+    "visual-programming",
+    "python",
+    "real-time",
+    "interactive-media"
+  ],
+  "license": "MIT",
+  "homepage": "https://github.com/8beeeaaat/touchdesigner-mcp"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
 				"@types/jsdom": "^21.1.7",
 				"@types/node": "^24.0.7",
 				"@vitest/coverage-v8": "^3.2.4",
+				"archiver": "^7.0.1",
 				"msw": "^2.10.2",
 				"mustache": "^4.2.0",
 				"npm-run-all": "^4.1.5",
@@ -3378,6 +3379,128 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/archiver": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+			"integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.2",
+				"async": "^3.2.4",
+				"buffer-crc32": "^1.0.0",
+				"readable-stream": "^4.0.0",
+				"readdir-glob": "^1.1.2",
+				"tar-stream": "^3.0.0",
+				"zip-stream": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+			"integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"glob": "^10.0.0",
+				"graceful-fs": "^4.2.0",
+				"is-stream": "^2.0.1",
+				"lazystream": "^1.0.0",
+				"lodash": "^4.17.15",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/archiver-utils/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
+		"node_modules/archiver/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/archiver/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3479,6 +3602,13 @@
 				"astring": "bin/astring"
 			}
 		},
+		"node_modules/async": {
+			"version": "3.2.6",
+			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/async-function": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -3522,12 +3652,27 @@
 				"proxy-from-env": "^1.1.0"
 			}
 		},
+		"node_modules/b4a": {
+			"version": "1.6.7",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
+			"integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bare-events": {
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+			"integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
@@ -3639,6 +3784,16 @@
 			"dependencies": {
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
+			}
+		},
+		"node_modules/buffer-crc32": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+			"integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"node_modules/bytes": {
@@ -3941,6 +4096,65 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/compress-commons": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+			"integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"crc32-stream": "^6.0.0",
+				"is-stream": "^2.0.1",
+				"normalize-path": "^3.0.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/compress-commons/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/compress-commons/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -4204,6 +4418,13 @@
 				"node": ">=6.6.0"
 			}
 		},
+		"node_modules/core-util-is": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/cors": {
 			"version": "2.8.5",
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -4215,6 +4436,75 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/crc-32": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"crc32": "bin/crc32.njs"
+			},
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/crc32-stream": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+			"integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"crc-32": "^1.2.0",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/crc32-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/cross-spawn": {
@@ -4865,6 +5155,16 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/eventsource": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
@@ -5016,6 +5316,13 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"license": "MIT"
+		},
+		"node_modules/fast-fifo": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+			"integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fast-glob": {
@@ -6651,6 +6958,59 @@
 				"node": "*"
 			}
 		},
+		"node_modules/lazystream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+			"integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^2.0.5"
+			},
+			"engines": {
+				"node": ">= 0.6.3"
+			}
+		},
+		"node_modules/lazystream/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lazystream/node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/lazystream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/lazystream/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7340,6 +7700,16 @@
 				"resolve": "^1.10.0",
 				"semver": "2 || 3 || 4 || 5",
 				"validate-npm-package-license": "^3.0.1"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/npm-run-all": {
@@ -8228,6 +8598,23 @@
 				"node": "^10 || ^12 || >=14"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/proxy-addr": {
 			"version": "2.0.7",
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8428,6 +8815,39 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/readdir-glob": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"minimatch": "^5.1.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/brace-expansion": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/readdir-glob/node_modules/minimatch": {
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/readdirp": {
@@ -9405,6 +9825,20 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/streamx": {
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
+			"integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fast-fifo": "^1.3.2",
+				"text-decoder": "^1.1.0"
+			},
+			"optionalDependencies": {
+				"bare-events": "^2.2.0"
+			}
+		},
 		"node_modules/strict-event-emitter": {
 			"version": "0.5.1",
 			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
@@ -9692,6 +10126,18 @@
 				"node": ">= 6"
 			}
 		},
+		"node_modules/tar-stream": {
+			"version": "3.1.7",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
+			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"b4a": "^1.6.4",
+				"fast-fifo": "^1.2.0",
+				"streamx": "^2.15.0"
+			}
+		},
 		"node_modules/test-exclude": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
@@ -9731,6 +10177,16 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/text-decoder": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
+			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"b4a": "^1.6.4"
 			}
 		},
 		"node_modules/through": {
@@ -10810,6 +11266,63 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zip-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+			"integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"archiver-utils": "^5.0.0",
+				"compress-commons": "^6.0.2",
+				"readable-stream": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/zip-stream/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/zip-stream/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/zod": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "0.4.0-alpha.5",
+	"version": "0.4.0-alpha.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "0.4.0-alpha.5",
+			"version": "0.4.0-alpha.6",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"@types/jsdom": "^21.1.7",
 		"@types/node": "^24.0.7",
 		"@vitest/coverage-v8": "^3.2.4",
+		"archiver": "^7.0.1",
 		"msw": "^2.10.2",
 		"mustache": "^4.2.0",
 		"npm-run-all": "^4.1.5",
@@ -60,6 +61,7 @@
 		"build": "run-s build:*",
 		"build:gen": "npm run gen",
 		"build:dist": "tsc && shx chmod +x dist/*.js",
+		"build:dxt": "npx @anthropic-ai/dxt pack",
 		"lint": "run-p lint:*",
 		"lint:biome": "biome check",
 		"lint:tsc": "tsc --noEmit",
@@ -72,7 +74,8 @@
 		"gen": "run-s gen:*",
 		"gen:webserver": "openapi-generator-cli generate -i ./src/api/index.yml -g python-flask -o ./td/modules/td_server",
 		"gen:handlers": "node td/genHandlers.js",
-		"gen:mcp": "orval --config ./orval.config.ts"
+		"gen:mcp": "orval --config ./orval.config.ts",
+		"package:dxt": "run-s build build:dxt"
 	},
 	"files": [
 		"dist/**/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "0.4.0-alpha.5",
+	"version": "0.4.0-alpha.6",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/src/api/index.yml
+++ b/src/api/index.yml
@@ -1,7 +1,7 @@
 info:
   description: OpenAPI schema for generating TouchDesigner API client code
   title: TouchDesigner API
-  version: 0.4.0-alpha.5
+  version: 0.4.0-alpha.6
 
 openapi: 3.0.0
 

--- a/src/server/touchDesignerServer.ts
+++ b/src/server/touchDesignerServer.ts
@@ -25,7 +25,7 @@ export class TouchDesignerServer {
 		this.server = new McpServer(
 			{
 				name: "TouchDesigner",
-				version: "0.4.0-alpha.5",
+				version: "0.4.0-alpha.6",
 			},
 			{
 				capabilities: {


### PR DESCRIPTION
## [0.4.0-alpha.6] - 2025-06-29

### Added
- **Desktop Extension (.dxt) Support**: Added full Desktop Extension (DXT) package support for Claude Desktop ([#82](https://github.com/8beeeaaat/touchdesigner-mcp/pull/82))
- New `manifest.json` file defining DXT package configuration with tools, prompts, and user configuration options
- User-configurable TouchDesigner port setting via DXT user interface
- Comprehensive tool definitions and descriptions in DXT manifest
- New `.dxtignore` file to exclude unnecessary files from DXT package

### Changed
- **GitHub Actions Workflow**: Enhanced release workflow to build and publish DXT packages automatically
  - Added DXT CLI tool installation and package building steps
  - Updated release body to include video demonstration links for setup instructions
- **README Updates**: Added visual demonstration links and improved installation instructions
  - Added GitHub user-attachments video links for TouchDesigner setup and DXT installation
  - Enhanced documentation for all installation methods (DXT, npx, Docker)
  - Updated both English and Japanese README files with video guides
- **gitignore**: Added DXT-related ignore patterns

### Documentation
- Enhanced installation documentation with visual guides and video demonstrations
- Improved DXT package distribution documentation
- Added comprehensive tool and prompt descriptions in DXT manifest

### Technical
- Version bumped to 0.4.0-alpha.6 across all relevant files
- DXT package workflow integrated into CI/CD pipeline
- Maintained backward compatibility with existing installation methods