### PR TITLE
fix DXT package build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,11 +53,8 @@ jobs:
           echo "Build artifacts extracted and package created!"
       - name: Build DXT package
         run: |
-          # Install DXT CLI tool
-          npm install -g @anthropic-ai/dxt
-
           # Build DXT package
-          npx @anthropic-ai/dxt pack
+          npm run build:dxt
 
           echo "DXT package created successfully!"
           ls -la *.dxt
@@ -117,7 +114,7 @@ jobs:
               "mcpServers": {
                 "touchdesigner": {
                   "command": "npx",
-                  "args": ["-y", "touchdesigner-mcp-server@prerelease", "--stdio"]
+                  "args": ["-y", "touchdesigner-mcp-server", "--stdio"]
                 }
               }
             }


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yml` file to streamline the build process for DXT packages and adjust the MCP server configuration. The most important changes include replacing the DXT CLI tool installation and usage with a custom build script and updating the MCP server dependency to use the stable version.

### Build process improvements:
* Replaced the installation and usage of the DXT CLI tool (`npm install -g @anthropic-ai/dxt` and `npx @anthropic-ai/dxt pack`) with a custom script (`npm run build:dxt`) to simplify the workflow.

### MCP server configuration updates:
* Updated the MCP server dependency from the prerelease version (`touchdesigner-mcp-server@prerelease`) to the stable version (`touchdesigner-mcp-server`) for improved reliability.