### PR TITLE
v0.4.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           submodules: recursive
       - name: Set up Docker environment
         run: |
-          echo "TD_WEB_SERVER_HOST=http://localhost" >> $GITHUB_ENV
+          echo "TD_WEB_SERVER_HOST=http://127.0.0.1" >> $GITHUB_ENV
           echo "TD_WEB_SERVER_PORT=9981" >> $GITHUB_ENV
       - name: Docker Compose Action
         uses: hoverkraft-tech/compose-action@v2.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4]
+
+### Fixed
+- **macOS Connection Issue**: Fixed IPv6/IPv4 mismatch causing connection failures on macOS ([#92](https://github.com/8beeeaaat/touchdesigner-mcp/pull/92))
+  - Changed default host from `localhost` to `127.0.0.1` to ensure IPv4 connection
+  - TouchDesigner WebServer only binds to IPv4, but `localhost` was resolving to IPv6 (`::1`) on some systems
+  - Updated CLI default configuration, test files, and CI/CD pipeline
+  - Resolves `connect ECONNREFUSED ::1:9981` error on macOS systems
+
+### Changed
+- **DXT Manifest Cleanup**: Removed unused `capabilities` section from DXT manifest configuration ([#93](https://github.com/8beeeaaat/touchdesigner-mcp/pull/93))
+  - Streamlined DXT package configuration for better compatibility
+  - Removed deprecated capabilities fields that were not utilized
+
 ## [0.4.3] - 2025-06-29
 
 ### Changed

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -1,7 +1,7 @@
 {
   "dxt_version": "0.1",
   "name": "touchdesigner-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -19,11 +19,7 @@
         "touchdesigner-mcp-server",
         "--stdio",
         "--port=${user_config.TD_WEB_SERVER_PORT}"
-      ],
-      "capabilities": {
-        "prompts": {},
-        "tools": {}
-      }
+      ]
     }
   },
   "tools": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "0.4.3",
+			"version": "0.4.4",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "0.4.3",
+	"version": "0.4.4",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/src/api/index.yml
+++ b/src/api/index.yml
@@ -1,7 +1,7 @@
 info:
   description: OpenAPI schema for generating TouchDesigner API client code
   title: TouchDesigner API
-  version: 0.4.3
+  version: 0.4.4
 
 openapi: 3.0.0
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,14 +5,17 @@ import { TouchDesignerServer } from "./server/touchDesignerServer.js";
 
 // Note: Environment variables should be set by the Desktop Extensions runtime or CLI arguments
 
+const DEFAULT_HOST = "http://127.0.0.1";
+const DEFAULT_PORT = 9981;
+
 /**
  * Parse command line arguments
  */
 export function parseArgs(args?: string[]) {
 	const argsToProcess = args || process.argv.slice(2);
 	const parsed = {
-		host: "http://localhost",
-		port: 9981,
+		host: DEFAULT_HOST,
+		port: DEFAULT_PORT,
 	};
 
 	for (let i = 0; i < argsToProcess.length; i++) {

--- a/src/server/touchDesignerServer.ts
+++ b/src/server/touchDesignerServer.ts
@@ -25,7 +25,7 @@ export class TouchDesignerServer {
 		this.server = new McpServer(
 			{
 				name: "TouchDesigner",
-				version: "0.4.3",
+				version: "0.4.4",
 			},
 			{
 				capabilities: {

--- a/tests/integration/touchDesignerClientAndWebServer.test.ts
+++ b/tests/integration/touchDesignerClientAndWebServer.test.ts
@@ -31,7 +31,7 @@ const tdClient = new TouchDesignerClient();
 
 describe("TouchDesigner Client E2E Tests", () => {
 	beforeAll(async () => {
-		process.env.TD_WEB_SERVER_HOST = "http://localhost";
+		process.env.TD_WEB_SERVER_HOST = "http://127.0.0.1";
 		process.env.TD_WEB_SERVER_PORT = "9981";
 		await tdClient.createNode({
 			parentPath: PROJECT_PATH,

--- a/tests/unit/cli.test.ts
+++ b/tests/unit/cli.test.ts
@@ -25,7 +25,7 @@ describe("CLI", () => {
 
 		it("should parse port argument correctly", () => {
 			expect(parseArgs(["--port=8080"])).toEqual({
-				host: "http://localhost",
+				host: "http://127.0.0.1",
 				port: 8080,
 			});
 		});
@@ -39,7 +39,7 @@ describe("CLI", () => {
 
 		it("should ignore malformed arguments", () => {
 			expect(parseArgs(["--host", "--port"])).toEqual({
-				host: "http://localhost",
+				host: "http://127.0.0.1",
 				port: 9981,
 			});
 		});

--- a/tests/unit/connectionManager.test.ts
+++ b/tests/unit/connectionManager.test.ts
@@ -45,7 +45,7 @@ describe("ConnectionManager", () => {
 		consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
 		// Setup environment variables
-		process.env.TD_WEB_SERVER_HOST = "http://localhost";
+		process.env.TD_WEB_SERVER_HOST = "http://127.0.0.1";
 		process.env.TD_WEB_SERVER_PORT = "9981";
 
 		connectionManager = new ConnectionManager(
@@ -75,7 +75,7 @@ describe("ConnectionManager", () => {
 			expect(result.success).toBe(true);
 			expect(mockServer.connect).toHaveBeenCalledWith(mockTransport);
 			expect(mockLogger.log).toHaveBeenCalledWith(
-				"Server connected and ready to process requests: http://localhost:9981",
+				"Server connected and ready to process requests: http://127.0.0.1:9981",
 			);
 			expect(mockTdClient.getTdInfo).toHaveBeenCalled();
 			expect(connectionManager.isConnected()).toBe(true);


### PR DESCRIPTION
## [0.4.4]

### Fixed
- **macOS Connection Issue**: Fixed IPv6/IPv4 mismatch causing connection failures on macOS ([#92](https://github.com/8beeeaaat/touchdesigner-mcp/pull/92))
  - Changed default host from `localhost` to `127.0.0.1` to ensure IPv4 connection
  - TouchDesigner WebServer only binds to IPv4, but `localhost` was resolving to IPv6 (`::1`) on some systems
  - Updated CLI default configuration, test files, and CI/CD pipeline
  - Resolves `connect ECONNREFUSED ::1:9981` error on macOS systems

### Changed
- **DXT Manifest Cleanup**: Removed unused `capabilities` section from DXT manifest configuration ([#93](https://github.com/8beeeaaat/touchdesigner-mcp/pull/93))
  - Streamlined DXT package configuration for better compatibility
  - Removed deprecated capabilities fields that were not utilized