### PR TITLE
update npm dependencies

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.2.0/schema.json",
 	"files": {
 		"includes": [
 			"**",
@@ -40,7 +40,13 @@
 			}
 		}
 	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
 	"vcs": {
 		"clientKind": "git",
 		"enabled": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,32 +9,32 @@
 			"version": "0.4.5",
 			"license": "MIT",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.13.2",
+				"@modelcontextprotocol/sdk": "^1.17.3",
 				"@mozilla/readability": "^0.6.0",
 				"@types/axios": "^0.14.4",
 				"@types/ws": "^8.18.1",
 				"@types/yargs": "^17.0.33",
-				"axios": "^1.10.0",
-				"zod": "^3.25.67"
+				"axios": "^1.11.0",
+				"zod": "3.25.76"
 			},
 			"bin": {
 				"touchdesigner-mcp-server": "dist/cli.js"
 			},
 			"devDependencies": {
-				"@biomejs/biome": "2.0.6",
-				"@openapitools/openapi-generator-cli": "^2.21.0",
+				"@biomejs/biome": "2.2.0",
+				"@openapitools/openapi-generator-cli": "^2.22.0",
 				"@types/jsdom": "^21.1.7",
-				"@types/node": "^24.0.7",
+				"@types/node": "^24.3.0",
 				"@vitest/coverage-v8": "^3.2.4",
 				"archiver": "^7.0.1",
-				"msw": "^2.10.2",
+				"msw": "^2.10.5",
 				"mustache": "^4.2.0",
 				"npm-run-all": "^4.1.5",
-				"orval": "^7.10.0",
+				"orval": "^7.11.2",
 				"shx": "^0.4.0",
-				"typescript": "^5.8.3",
+				"typescript": "^5.9.2",
 				"vitest": "^3.2.4",
-				"yaml": "^2.8.0"
+				"yaml": "^2.8.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -145,9 +145,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@asyncapi/specs": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.8.1.tgz",
-			"integrity": "sha512-czHoAk3PeXTLR+X8IUaD+IpT+g+zUvkcgMDJVothBsan+oHN3jfcFcFUNdOPAAFoUCQN1hXF1dWuphWy05THlA==",
+			"version": "6.9.0",
+			"resolved": "https://registry.npmjs.org/@asyncapi/specs/-/specs-6.9.0.tgz",
+			"integrity": "sha512-gatFEH2hfJXWmv3vogIjBZfiIbPRC/ISn9UEHZZLZDdMBO0USxt3AFgCC9AY1P+eNE7zjXddXCIT7gz32XOK4g==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -190,16 +190,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@babel/runtime": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.1.tgz",
-			"integrity": "sha512-1x3D2xEk2fRo3PAhwQwu5UubzgiVWSXTBfWpVd2Mx2AzRqJuDJCsgaDVZ7HB5iGzDW1Hl1sWN2mFyKjmR9uAog==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/types": {
 			"version": "7.27.0",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
@@ -225,9 +215,9 @@
 			}
 		},
 		"node_modules/@biomejs/biome": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.0.6.tgz",
-			"integrity": "sha512-RRP+9cdh5qwe2t0gORwXaa27oTOiQRQvrFf49x2PA1tnpsyU7FIHX4ZOFMtBC4QNtyWsN7Dqkf5EDbg4X+9iqA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.2.0.tgz",
+			"integrity": "sha512-3On3RSYLsX+n9KnoSgfoYlckYBoU6VRM22cw1gB4Y0OuUVSYd/O/2saOJMrA4HFfA1Ff0eacOvMN1yAAvHtzIw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"bin": {
@@ -241,20 +231,20 @@
 				"url": "https://opencollective.com/biome"
 			},
 			"optionalDependencies": {
-				"@biomejs/cli-darwin-arm64": "2.0.6",
-				"@biomejs/cli-darwin-x64": "2.0.6",
-				"@biomejs/cli-linux-arm64": "2.0.6",
-				"@biomejs/cli-linux-arm64-musl": "2.0.6",
-				"@biomejs/cli-linux-x64": "2.0.6",
-				"@biomejs/cli-linux-x64-musl": "2.0.6",
-				"@biomejs/cli-win32-arm64": "2.0.6",
-				"@biomejs/cli-win32-x64": "2.0.6"
+				"@biomejs/cli-darwin-arm64": "2.2.0",
+				"@biomejs/cli-darwin-x64": "2.2.0",
+				"@biomejs/cli-linux-arm64": "2.2.0",
+				"@biomejs/cli-linux-arm64-musl": "2.2.0",
+				"@biomejs/cli-linux-x64": "2.2.0",
+				"@biomejs/cli-linux-x64-musl": "2.2.0",
+				"@biomejs/cli-win32-arm64": "2.2.0",
+				"@biomejs/cli-win32-x64": "2.2.0"
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.0.6.tgz",
-			"integrity": "sha512-AzdiNNjNzsE6LfqWyBvcL29uWoIuZUkndu+wwlXW13EKcBHbbKjNQEZIJKYDc6IL+p7bmWGx3v9ZtcRyIoIz5A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.2.0.tgz",
+			"integrity": "sha512-zKbwUUh+9uFmWfS8IFxmVD6XwqFcENjZvEyfOxHs1epjdH3wyyMQG80FGDsmauPwS2r5kXdEM0v/+dTIA9FXAg==",
 			"cpu": [
 				"arm64"
 			],
@@ -269,9 +259,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-darwin-x64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.0.6.tgz",
-			"integrity": "sha512-wJjjP4E7bO4WJmiQaLnsdXMa516dbtC6542qeRkyJg0MqMXP0fvs4gdsHhZ7p9XWTAmGIjZHFKXdsjBvKGIJJQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.2.0.tgz",
+			"integrity": "sha512-+OmT4dsX2eTfhD5crUOPw3RPhaR+SKVspvGVmSdZ9y9O/AgL8pla6T4hOn1q+VAFBHuHhsdxDRJgFCSC7RaMOw==",
 			"cpu": [
 				"x64"
 			],
@@ -286,9 +276,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.0.6.tgz",
-			"integrity": "sha512-ZSVf6TYo5rNMUHIW1tww+rs/krol7U5A1Is/yzWyHVZguuB0lBnIodqyFuwCNqG9aJGyk7xIMS8HG0qGUPz0SA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.2.0.tgz",
+			"integrity": "sha512-6eoRdF2yW5FnW9Lpeivh7Mayhq0KDdaDMYOJnH9aT02KuSIX5V1HmWJCQQPwIQbhDh68Zrcpl8inRlTEan0SXw==",
 			"cpu": [
 				"arm64"
 			],
@@ -303,9 +293,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-arm64-musl": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.0.6.tgz",
-			"integrity": "sha512-CVPEMlin3bW49sBqLBg2x016Pws7eUXA27XYDFlEtponD0luYjg2zQaMJ2nOqlkKG9fqzzkamdYxHdMDc2gZFw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.2.0.tgz",
+			"integrity": "sha512-egKpOa+4FL9YO+SMUMLUvf543cprjevNc3CAgDNFLcjknuNMcZ0GLJYa3EGTCR2xIkIUJDVneBV3O9OcIlCEZQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -320,9 +310,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.0.6.tgz",
-			"integrity": "sha512-geM1MkHTV1Kh2Cs/Xzot9BOF3WBacihw6bkEmxkz4nSga8B9/hWy5BDiOG3gHDGIBa8WxT0nzsJs2f/hPqQIQw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.2.0.tgz",
+			"integrity": "sha512-5UmQx/OZAfJfi25zAnAGHUMuOd+LOsliIt119x2soA2gLggQYrVPA+2kMUxR6Mw5M1deUF/AWWP2qpxgH7Nyfw==",
 			"cpu": [
 				"x64"
 			],
@@ -337,9 +327,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-linux-x64-musl": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.0.6.tgz",
-			"integrity": "sha512-mKHE/e954hR/hSnAcJSjkf4xGqZc/53Kh39HVW1EgO5iFi0JutTN07TSjEMg616julRtfSNJi0KNyxvc30Y4rQ==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.2.0.tgz",
+			"integrity": "sha512-I5J85yWwUWpgJyC1CcytNSGusu2p9HjDnOPAFG4Y515hwRD0jpR9sT9/T1cKHtuCvEQ/sBvx+6zhz9l9wEJGAg==",
 			"cpu": [
 				"x64"
 			],
@@ -354,9 +344,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-arm64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.0.6.tgz",
-			"integrity": "sha512-290V4oSFoKaprKE1zkYVsDfAdn0An5DowZ+GIABgjoq1ndhvNxkJcpxPsiYtT7slbVe3xmlT0ncdfOsN7KruzA==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.2.0.tgz",
+			"integrity": "sha512-n9a1/f2CwIDmNMNkFs+JI0ZjFnMO0jdOyGNtihgUNFnlmd84yIYY2KMTBmMV58ZlVHjgmY5Y6E1hVTnSRieggA==",
 			"cpu": [
 				"arm64"
 			],
@@ -371,9 +361,9 @@
 			}
 		},
 		"node_modules/@biomejs/cli-win32-x64": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.0.6.tgz",
-			"integrity": "sha512-bfM1Bce0d69Ao7pjTjUS+AWSZ02+5UHdiAP85Th8e9yV5xzw6JrHXbL5YWlcEKQ84FIZMdDc7ncuti1wd2sdbw==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.2.0.tgz",
+			"integrity": "sha512-Nawu5nHjP/zPKTIryh2AavzTc/KEg4um/MxWdXW0A6P/RZOyIpa7+QSjeXwAwX/utJGaCoXRPWtF3m5U/bB3Ww==",
 			"cpu": [
 				"x64"
 			],
@@ -385,6 +375,17 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@borewit/text-codec": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.1.1.tgz",
+			"integrity": "sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/@bundled-es-modules/cookie": {
@@ -419,9 +420,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-			"integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
+			"integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -436,9 +437,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-			"integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
+			"integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
 			"cpu": [
 				"arm"
 			],
@@ -453,9 +454,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-			"integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
+			"integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
 			"cpu": [
 				"arm64"
 			],
@@ -470,9 +471,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-			"integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
+			"integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
 			"cpu": [
 				"x64"
 			],
@@ -487,9 +488,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-			"integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
+			"integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
 			"cpu": [
 				"arm64"
 			],
@@ -504,9 +505,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-			"integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
+			"integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
 			"cpu": [
 				"x64"
 			],
@@ -521,9 +522,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -538,9 +539,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-			"integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
+			"integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
 			"cpu": [
 				"x64"
 			],
@@ -555,9 +556,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-			"integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
+			"integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
 			"cpu": [
 				"arm"
 			],
@@ -572,9 +573,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-			"integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
+			"integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
 			"cpu": [
 				"arm64"
 			],
@@ -589,9 +590,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-			"integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
+			"integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
 			"cpu": [
 				"ia32"
 			],
@@ -606,9 +607,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-			"integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
+			"integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
 			"cpu": [
 				"loong64"
 			],
@@ -623,9 +624,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-			"integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
+			"integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
 			"cpu": [
 				"mips64el"
 			],
@@ -640,9 +641,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-			"integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
+			"integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
 			"cpu": [
 				"ppc64"
 			],
@@ -657,9 +658,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-			"integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
+			"integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
 			"cpu": [
 				"riscv64"
 			],
@@ -674,9 +675,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-			"integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
+			"integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
 			"cpu": [
 				"s390x"
 			],
@@ -691,9 +692,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-			"integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
+			"integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
 			"cpu": [
 				"x64"
 			],
@@ -708,9 +709,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -725,9 +726,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-			"integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
+			"integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
 			"cpu": [
 				"x64"
 			],
@@ -742,9 +743,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-			"integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
+			"integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -759,9 +760,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-			"integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
+			"integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
 			"cpu": [
 				"x64"
 			],
@@ -775,10 +776,27 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@esbuild/openharmony-arm64": {
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.9.tgz",
+			"integrity": "sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"openharmony"
+			],
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-			"integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
+			"integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
 			"cpu": [
 				"x64"
 			],
@@ -793,9 +811,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-			"integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
+			"integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -810,9 +828,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-			"integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
+			"integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
 			"cpu": [
 				"ia32"
 			],
@@ -827,9 +845,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-			"integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
+			"integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
 			"cpu": [
 				"x64"
 			],
@@ -851,23 +869,23 @@
 			"license": "MIT"
 		},
 		"node_modules/@gerrit0/mini-shiki": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.3.tgz",
-			"integrity": "sha512-yemSYr0Oiqk5NAQRfbD5DKUTlThiZw1MxTMx/YpQTg6m4QRJDtV2JTYSuNevgx1ayy/O7x+uwDjh3IgECGFY/Q==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.9.2.tgz",
+			"integrity": "sha512-Tvsj+AOO4Z8xLRJK900WkyfxHsZQu+Zm1//oT1w443PO6RiYMoq/4NGOhaNuZoUMYsjKIAPVQ6eOFMddj6yphQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-oniguruma": "^3.2.2",
-				"@shikijs/langs": "^3.2.2",
-				"@shikijs/themes": "^3.2.2",
-				"@shikijs/types": "^3.2.2",
+				"@shikijs/engine-oniguruma": "^3.9.2",
+				"@shikijs/langs": "^3.9.2",
+				"@shikijs/themes": "^3.9.2",
+				"@shikijs/types": "^3.9.2",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@ibm-cloud/openapi-ruleset": {
-			"version": "1.31.1",
-			"resolved": "https://registry.npmjs.org/@ibm-cloud/openapi-ruleset/-/openapi-ruleset-1.31.1.tgz",
-			"integrity": "sha512-3WK2FREmDA2aadCjD71PE7tx5evyvmhg80ts1kXp2IzXIA0ZJ7guGM66tj40kxaqwpMSGchwEnnfYswntav76g==",
+			"version": "1.31.2",
+			"resolved": "https://registry.npmjs.org/@ibm-cloud/openapi-ruleset/-/openapi-ruleset-1.31.2.tgz",
+			"integrity": "sha512-g3YYNTiX6zW7quFvDD9szu+54oHj6+4vz8g3/ikOacVsVEX072CvhjX9zRZf1WH4zDXv8KbprsxV+osZQbXPlg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1036,6 +1054,28 @@
 				"signal-exit": "^4.1.0",
 				"wrap-ansi": "^6.2.0",
 				"yoctocolors-cjs": "^2.1.2"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+			"integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.0",
+				"iconv-lite": "^0.6.3"
 			},
 			"engines": {
 				"node": ">=18"
@@ -1323,9 +1363,9 @@
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.13.2",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.13.2.tgz",
-			"integrity": "sha512-Vx7qOcmoKkR3qhaQ9qf3GxiVKCEu+zfJddHv6x3dY/9P6+uIwJnmuAur5aB+4FDXf41rRrDnOEGkviX5oYZ67w==",
+			"version": "1.17.3",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.3.tgz",
+			"integrity": "sha512-JPwUKWSsbzx+DLFznf/QZ32Qa+ptfbUlHhRLrBQBAFu9iI1iYvizM4p+zhhRDceSsPutXp4z+R/HPVphlIiclg==",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.6",
@@ -1333,6 +1373,7 @@
 				"cors": "^2.8.5",
 				"cross-spawn": "^7.0.5",
 				"eventsource": "^3.0.2",
+				"eventsource-parser": "^3.0.0",
 				"express": "^5.0.1",
 				"express-rate-limit": "^7.5.0",
 				"pkce-challenge": "^5.0.0",
@@ -1342,6 +1383,15 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/zod-to-json-schema": {
+			"version": "3.24.6",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+			"integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.24.1"
 			}
 		},
 		"node_modules/@mozilla/readability": {
@@ -1372,9 +1422,9 @@
 			}
 		},
 		"node_modules/@nestjs/axios": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.0.tgz",
-			"integrity": "sha512-1cB+Jyltu/uUPNQrpUimRHEQHrnQrpLzVj6dU3dgn6iDDDdahr10TgHFGTmw5VuJ9GzKZsCLDL78VSwJAs/9JQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-4.0.1.tgz",
+			"integrity": "sha512-68pFJgu+/AZbWkGu65Z3r55bTsCPlgyKaV4BSG8yUAD72q1PPuyVRgUwFv6BxdnibTUHlyxm06FmYWNC+bjN7A==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -1384,9 +1434,9 @@
 			}
 		},
 		"node_modules/@nestjs/common": {
-			"version": "11.1.3",
-			"resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.3.tgz",
-			"integrity": "sha512-ogEK+GriWodIwCw6buQ1rpcH4Kx+G7YQ9EwuPySI3rS05pSdtQ++UhucjusSI9apNidv+QURBztJkRecwwJQXg==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.6.tgz",
+			"integrity": "sha512-krKwLLcFmeuKDqngG2N/RuZHCs2ycsKcxWIDgcm7i1lf3sQ0iG03ci+DsP/r3FcT/eJDFsIHnKtNta2LIi7PzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1416,9 +1466,9 @@
 			}
 		},
 		"node_modules/@nestjs/core": {
-			"version": "11.1.3",
-			"resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.3.tgz",
-			"integrity": "sha512-5lTni0TCh8x7bXETRD57pQFnKnEg1T6M+VLE7wAmyQRIecKQU+2inRGZD+A4v2DC1I04eA0WffP0GKLxjOKlzw==",
+			"version": "11.1.6",
+			"resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.6.tgz",
+			"integrity": "sha512-siWX7UDgErisW18VTeJA+x+/tpNZrJewjTBsRPF3JVxuWRuAB1kRoiJcxHgln8Lb5UY9NdvklITR84DUEXD0Cg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -1640,27 +1690,26 @@
 			"license": "MIT"
 		},
 		"node_modules/@openapitools/openapi-generator-cli": {
-			"version": "2.21.0",
-			"resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.21.0.tgz",
-			"integrity": "sha512-NdDvCd7hya+UucxH7G94Jf6tmA6641I4CF/T3xtFhM+NQQNWAP5tpiOBN4Ub9ocU6cCgQgXdWl4EpwlEwW7JDQ==",
+			"version": "2.22.0",
+			"resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-2.22.0.tgz",
+			"integrity": "sha512-HdjSiKsXpbnXBcSCnft494fv5pFZxPKFAV1eR+yMjo3bt1ONLb7OGy1D/5SrbjRfy9b82JcYUJ3gssh49suWKg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@nestjs/axios": "4.0.0",
-				"@nestjs/common": "11.1.3",
-				"@nestjs/core": "11.1.3",
+				"@nestjs/axios": "4.0.1",
+				"@nestjs/common": "11.1.6",
+				"@nestjs/core": "11.1.6",
 				"@nuxtjs/opencollective": "0.3.2",
-				"axios": "1.10.0",
+				"axios": "1.11.0",
 				"chalk": "4.1.2",
 				"commander": "8.3.0",
 				"compare-versions": "4.1.4",
-				"concurrently": "6.5.1",
+				"concurrently": "9.2.0",
 				"console.table": "0.10.0",
-				"fs-extra": "11.3.0",
+				"fs-extra": "11.3.1",
 				"glob": "11.0.3",
-				"inquirer": "8.2.6",
-				"lodash": "4.17.21",
+				"inquirer": "8.2.7",
 				"proxy-agent": "6.5.0",
 				"reflect-metadata": "0.2.2",
 				"rxjs": "7.8.2",
@@ -1844,29 +1893,29 @@
 			}
 		},
 		"node_modules/@orval/angular": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/angular/-/angular-7.10.0.tgz",
-			"integrity": "sha512-M89GKo/PibxYXvOKp9+i6BLxhEW8YsO+evwuV2kMbDGNS3RiYDwzmMBcA9SVL7m8CumeZoxNEAXsupzq96ZAXA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/angular/-/angular-7.11.2.tgz",
+			"integrity": "sha512-v7I3MXlc1DTFHZlCo10uqBmss/4puXi1EbYdlYGfeZ2sYQiwtRFEYAMnSIxHzMtdtI4jd7iDEH0fZRA7W6yloA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0"
+				"@orval/core": "7.11.2"
 			}
 		},
 		"node_modules/@orval/axios": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/axios/-/axios-7.10.0.tgz",
-			"integrity": "sha512-AB6BjEwyguIcH8olzOTFPvwUP8z63yP4Jfl3T2UoeFchK04KqWqxbUoxmDG9xVQ79uMs/uOrb0X+GFwdZ56gAg==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/axios/-/axios-7.11.2.tgz",
+			"integrity": "sha512-X5TJTFofCeJrQcHWoH0wz/032DBhPOQuZUUOPYO3DItOnq9/nfHJYKnUfg13wtYw0LVjCxyTZpeGLUBZnY804A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0"
+				"@orval/core": "7.11.2"
 			}
 		},
 		"node_modules/@orval/core": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/core/-/core-7.10.0.tgz",
-			"integrity": "sha512-Lm7HY4Kwzehe+2HNfi+Ov/IZ+m3nj3NskVGvOyJDAqaaHB7G/xydSCtgELG32ur4G+M/XmwChAjoP4TCNVh0VA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/core/-/core-7.11.2.tgz",
+			"integrity": "sha512-5k2j4ro53yZ3J+tGMu3LpLgVb2OBtxNDgyrJik8qkrFyuORBLx/a+AJRFoPYwZmtnMZzzRXoH4J/fbpW5LXIyg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1876,8 +1925,8 @@
 				"ajv": "^8.17.1",
 				"chalk": "^4.1.2",
 				"compare-versions": "^6.1.1",
-				"debug": "^4.4.0",
-				"esbuild": "^0.25.1",
+				"debug": "^4.4.1",
+				"esbuild": "^0.25.8",
 				"esutils": "2.0.3",
 				"fs-extra": "^11.3.0",
 				"globby": "11.1.0",
@@ -2001,80 +2050,81 @@
 			}
 		},
 		"node_modules/@orval/fetch": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-7.10.0.tgz",
-			"integrity": "sha512-bWcXPmARcXhXRveBtUnkfPlkUcLEzfGaflAdqN4CtScS48LgNrXXtuyt2BV2wvEXAavCWIhnRyQvz2foTU4U8Q==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-7.11.2.tgz",
+			"integrity": "sha512-FuupASqk4Dn8ZET7u5Ra5djKy22KfRfec60zRR/o5+L5iQkWKEe/A5DBT1PwjTMnp9789PEGlFPQjZNwMG98Tg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0"
+				"@orval/core": "7.11.2"
 			}
 		},
 		"node_modules/@orval/hono": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/hono/-/hono-7.10.0.tgz",
-			"integrity": "sha512-bOxTdZxx2BpGQf7fFuCeeUe//ZYDWc6Yz9WOhj3HrnsD06xTRKFWVBi/QZ29QcAPxqwunu/VWwbqoiHHuuX3bA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/hono/-/hono-7.11.2.tgz",
+			"integrity": "sha512-SddhKMYMB/dJH3YQx3xi0Zd+4tfhrEkqJdqQaYLXgENJiw0aGbdaZTdY6mb/e6qP38TTK6ME2PkYOqwkl2DQ7g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0",
-				"@orval/zod": "7.10.0",
+				"@orval/core": "7.11.2",
+				"@orval/zod": "7.11.2",
 				"lodash.uniq": "^4.5.0"
 			}
 		},
 		"node_modules/@orval/mcp": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-7.10.0.tgz",
-			"integrity": "sha512-ztLXGOSxK7jFwPKAeYPR85BjKRh3KTClKEnM2MFmo2FHHojn72DPXRPCmy0Wbw5Ee+JOxK2kIpyx+HZi9XVxiA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-7.11.2.tgz",
+			"integrity": "sha512-9kGKko8wLuCbeETp8Pd8lXLtBpLzEJfR2kl2m19AI3nAoHXE/Tnn3KgjMIg0qvCcsRXGXdYJB7wfxy2URdAxVA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0",
-				"@orval/zod": "7.10.0"
+				"@orval/core": "7.11.2",
+				"@orval/fetch": "7.11.2",
+				"@orval/zod": "7.11.2"
 			}
 		},
 		"node_modules/@orval/mock": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/mock/-/mock-7.10.0.tgz",
-			"integrity": "sha512-vkEWCaKEyMfWGJF5MtxVzl+blwc9vYzwdYxMoSdjA5yS2dNBrdNlt1aLtb4+aoI1jgBgpCg/OB7VtWaL5QYidA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/mock/-/mock-7.11.2.tgz",
+			"integrity": "sha512-+uRq6BT6NU2z0UQtgeD6FMuLAxQ5bjJ5PZK3AsbDYFRSmAWUWoeaQcoWyF38F4t7ez779beGs3AlUg+z0Ec4rQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0",
+				"@orval/core": "7.11.2",
 				"openapi3-ts": "^4.2.2"
 			}
 		},
 		"node_modules/@orval/query": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/query/-/query-7.10.0.tgz",
-			"integrity": "sha512-DBVg8RyKWSQKhr5Zfvxx5XICUdDUkG4MJKSd4BQCrRjUWgN6vwGunMEKyfnjpS5mFUSCkwWD/I3rTkjW6aysJA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/query/-/query-7.11.2.tgz",
+			"integrity": "sha512-C/it+wNfcDtuvpB6h/78YwWU+Rjk7eU1Av8jAoGnvxMRli4nnzhSZ83HMILGhYQbE9WcfNZxQJ6OaBoTWqACPg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0",
-				"@orval/fetch": "7.10.0",
+				"@orval/core": "7.11.2",
+				"@orval/fetch": "7.11.2",
 				"lodash.omitby": "^4.6.0"
 			}
 		},
 		"node_modules/@orval/swr": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/swr/-/swr-7.10.0.tgz",
-			"integrity": "sha512-ZdApomZQhJ5ZogjJgBK+haeCOP9gUaMaGKGjTVJr86jJaygDcKn54Ok1quiDUCbX42Eye+cgmQJeKeZvqnPohA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/swr/-/swr-7.11.2.tgz",
+			"integrity": "sha512-95GkKLVy67xJvsiVvK4nTOsCpebWM54FvQdKQaqlJ0FGCNUbqDjVRwBKbjP6dLc/B3wTmBAWlFSLbdVmjGCTYg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0",
-				"@orval/fetch": "7.10.0"
+				"@orval/core": "7.11.2",
+				"@orval/fetch": "7.11.2"
 			}
 		},
 		"node_modules/@orval/zod": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/@orval/zod/-/zod-7.10.0.tgz",
-			"integrity": "sha512-AB/508IBMlVDBcGvlq+ASz7DvqU3nhoDnIeBCyjwNfQwhYzREU0qqiFBnH0XAW70c6SCMf9/bIcYbw8GAx/zxA==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/@orval/zod/-/zod-7.11.2.tgz",
+			"integrity": "sha512-4MzTg5Wms8/LlM3CbYu80dvCbP88bVlQjnYsBdFXuEv0K2GYkBCAhVOrmXCVrPXE89neV6ABkvWQeuKZQpkdxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "7.10.0",
+				"@orval/core": "7.11.2",
 				"lodash.uniq": "^4.5.0"
 			}
 		},
@@ -2370,40 +2420,40 @@
 			]
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
-			"integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.9.2.tgz",
+			"integrity": "sha512-Vn/w5oyQ6TUgTVDIC/BrpXwIlfK6V6kGWDVVz2eRkF2v13YoENUvaNwxMsQU/t6oCuZKzqp9vqtEtEzKl9VegA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.2.2",
+				"@shikijs/types": "3.9.2",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@shikijs/langs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
-			"integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.9.2.tgz",
+			"integrity": "sha512-X1Q6wRRQXY7HqAuX3I8WjMscjeGjqXCg/Sve7J2GWFORXkSrXud23UECqTBIdCSNKJioFtmUGJQNKtlMMZMn0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.2.2"
+				"@shikijs/types": "3.9.2"
 			}
 		},
 		"node_modules/@shikijs/themes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
-			"integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.9.2.tgz",
+			"integrity": "sha512-6z5lBPBMRfLyyEsgf6uJDHPa6NAGVzFJqH4EAZ+03+7sedYir2yJBRu2uPZOKmj43GyhVHWHvyduLDAwJQfDjA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.2.2"
+				"@shikijs/types": "3.9.2"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
-			"integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
+			"version": "3.9.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.9.2.tgz",
+			"integrity": "sha512-/M5L0Uc2ljyn2jKvj4Yiah7ow/W+DJSglVafvWAJ/b8AZDeeRAdMu3c2riDzB7N42VD+jSnWxeP9AKtd4TfYVw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3001,12 +3051,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "24.0.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.7.tgz",
-			"integrity": "sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==",
+			"version": "24.3.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+			"integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.8.0"
+				"undici-types": "~7.10.0"
 			}
 		},
 		"node_modules/@types/statuses": {
@@ -3642,13 +3692,13 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-			"integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+			"integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
-				"form-data": "^4.0.0",
+				"form-data": "^4.0.4",
 				"proxy-from-env": "^1.1.0"
 			}
 		},
@@ -3738,9 +3788,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "1.1.12",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3903,9 +3953,9 @@
 			}
 		},
 		"node_modules/chardet": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+			"integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4163,26 +4213,29 @@
 			"license": "MIT"
 		},
 		"node_modules/concurrently": {
-			"version": "6.5.1",
-			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-6.5.1.tgz",
-			"integrity": "sha512-FlSwNpGjWQfRwPLXvJ/OgysbBxPkWpiVjy1042b0U7on7S7qwwMIILRj7WTN1mTgqa582bG6NFuScOoh6Zgdag==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.2.0.tgz",
+			"integrity": "sha512-IsB/fiXTupmagMW4MNp2lx2cdSN2FfZq78vF90LBB+zZHArbIQZjQtzXCiXnvTxCZSvXanTqFLWBjw2UkLx1SQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"chalk": "^4.1.0",
-				"date-fns": "^2.16.1",
+				"chalk": "^4.1.2",
 				"lodash": "^4.17.21",
-				"rxjs": "^6.6.3",
-				"spawn-command": "^0.0.2-1",
-				"supports-color": "^8.1.0",
+				"rxjs": "^7.8.1",
+				"shell-quote": "^1.8.1",
+				"supports-color": "^8.1.1",
 				"tree-kill": "^1.2.2",
-				"yargs": "^16.2.0"
+				"yargs": "^17.7.2"
 			},
 			"bin": {
-				"concurrently": "bin/concurrently.js"
+				"conc": "dist/bin/concurrently.js",
+				"concurrently": "dist/bin/concurrently.js"
 			},
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
 			}
 		},
 		"node_modules/concurrently/node_modules/ansi-styles": {
@@ -4231,18 +4284,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/concurrently/node_modules/cliui": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-			"integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"string-width": "^4.2.0",
-				"strip-ansi": "^6.0.0",
-				"wrap-ansi": "^7.0.0"
-			}
-		},
 		"node_modules/concurrently/node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4273,19 +4314,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/concurrently/node_modules/rxjs": {
-			"version": "6.6.7",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-			"integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^1.9.0"
-			},
-			"engines": {
-				"npm": ">=2.0.0"
-			}
-		},
 		"node_modules/concurrently/node_modules/supports-color": {
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -4300,60 +4328,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
-		"node_modules/concurrently/node_modules/tslib": {
-			"version": "1.14.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"dev": true,
-			"license": "0BSD"
-		},
-		"node_modules/concurrently/node_modules/wrap-ansi": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^4.0.0",
-				"string-width": "^4.1.0",
-				"strip-ansi": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/concurrently/node_modules/yargs": {
-			"version": "16.2.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cliui": "^7.0.2",
-				"escalade": "^3.1.1",
-				"get-caller-file": "^2.0.5",
-				"require-directory": "^2.1.1",
-				"string-width": "^4.2.0",
-				"y18n": "^5.0.5",
-				"yargs-parser": "^20.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/concurrently/node_modules/yargs-parser": {
-			"version": "20.2.9",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/consola": {
@@ -4583,23 +4557,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/date-fns": {
-			"version": "2.30.0",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-			"integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.21.0"
-			},
-			"engines": {
-				"node": ">=0.11"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/date-fns"
 			}
 		},
 		"node_modules/debug": {
@@ -5004,9 +4961,9 @@
 			"license": "MIT"
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.5",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+			"version": "0.25.9",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
+			"integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5017,31 +4974,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.5",
-				"@esbuild/android-arm": "0.25.5",
-				"@esbuild/android-arm64": "0.25.5",
-				"@esbuild/android-x64": "0.25.5",
-				"@esbuild/darwin-arm64": "0.25.5",
-				"@esbuild/darwin-x64": "0.25.5",
-				"@esbuild/freebsd-arm64": "0.25.5",
-				"@esbuild/freebsd-x64": "0.25.5",
-				"@esbuild/linux-arm": "0.25.5",
-				"@esbuild/linux-arm64": "0.25.5",
-				"@esbuild/linux-ia32": "0.25.5",
-				"@esbuild/linux-loong64": "0.25.5",
-				"@esbuild/linux-mips64el": "0.25.5",
-				"@esbuild/linux-ppc64": "0.25.5",
-				"@esbuild/linux-riscv64": "0.25.5",
-				"@esbuild/linux-s390x": "0.25.5",
-				"@esbuild/linux-x64": "0.25.5",
-				"@esbuild/netbsd-arm64": "0.25.5",
-				"@esbuild/netbsd-x64": "0.25.5",
-				"@esbuild/openbsd-arm64": "0.25.5",
-				"@esbuild/openbsd-x64": "0.25.5",
-				"@esbuild/sunos-x64": "0.25.5",
-				"@esbuild/win32-arm64": "0.25.5",
-				"@esbuild/win32-ia32": "0.25.5",
-				"@esbuild/win32-x64": "0.25.5"
+				"@esbuild/aix-ppc64": "0.25.9",
+				"@esbuild/android-arm": "0.25.9",
+				"@esbuild/android-arm64": "0.25.9",
+				"@esbuild/android-x64": "0.25.9",
+				"@esbuild/darwin-arm64": "0.25.9",
+				"@esbuild/darwin-x64": "0.25.9",
+				"@esbuild/freebsd-arm64": "0.25.9",
+				"@esbuild/freebsd-x64": "0.25.9",
+				"@esbuild/linux-arm": "0.25.9",
+				"@esbuild/linux-arm64": "0.25.9",
+				"@esbuild/linux-ia32": "0.25.9",
+				"@esbuild/linux-loong64": "0.25.9",
+				"@esbuild/linux-mips64el": "0.25.9",
+				"@esbuild/linux-ppc64": "0.25.9",
+				"@esbuild/linux-riscv64": "0.25.9",
+				"@esbuild/linux-s390x": "0.25.9",
+				"@esbuild/linux-x64": "0.25.9",
+				"@esbuild/netbsd-arm64": "0.25.9",
+				"@esbuild/netbsd-x64": "0.25.9",
+				"@esbuild/openbsd-arm64": "0.25.9",
+				"@esbuild/openbsd-x64": "0.25.9",
+				"@esbuild/openharmony-arm64": "0.25.9",
+				"@esbuild/sunos-x64": "0.25.9",
+				"@esbuild/win32-arm64": "0.25.9",
+				"@esbuild/win32-ia32": "0.25.9",
+				"@esbuild/win32-x64": "0.25.9"
 			}
 		},
 		"node_modules/escalade": {
@@ -5166,9 +5124,9 @@
 			}
 		},
 		"node_modules/eventsource": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.6.tgz",
-			"integrity": "sha512-l19WpE2m9hSuyP06+FbuUUf1G+R0SFLrtQfbRb9PRr+oimOfxQhgGCbVaXg5IvZyyTThJsxh6L/srkMiCeBPDA==",
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
 			"license": "MIT",
 			"dependencies": {
 				"eventsource-parser": "^3.0.1"
@@ -5178,12 +5136,12 @@
 			}
 		},
 		"node_modules/eventsource-parser": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-			"integrity": "sha512-VARTJ9CYeuQYb0pZEPbzi740OWFgpHe7AYJ2WFZVnUDUQp5Dk2yJUgF36YsZ81cOyxT0QxmXD2EQpapAouzWVA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.3.tgz",
+			"integrity": "sha512-nVpZkTMM9rF6AQ9gPJpFsNAMt48wIzB5TQgiTLdHiuO8XEDhUgZEhqKlZWXbIzo9VmJ/HvysHqEaVeD5v9TPvA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/execa": {
@@ -5270,9 +5228,9 @@
 			}
 		},
 		"node_modules/express-rate-limit": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-			"integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+			"version": "7.5.1",
+			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+			"integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 16"
@@ -5281,35 +5239,7 @@
 				"url": "https://github.com/sponsors/express-rate-limit"
 			},
 			"peerDependencies": {
-				"express": "^4.11 || 5 || ^5.0.0-beta.1"
-			}
-		},
-		"node_modules/external-editor": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-			"integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chardet": "^0.7.0",
-				"iconv-lite": "^0.4.24",
-				"tmp": "^0.0.33"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/external-editor/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"express": ">= 4.11"
 			}
 		},
 		"node_modules/fast-deep-equal": {
@@ -5532,14 +5462,15 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-			"integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+			"integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.12"
 			},
 			"engines": {
@@ -5586,9 +5517,9 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "11.3.0",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-			"integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+			"version": "11.3.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+			"integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5783,9 +5714,9 @@
 			}
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6109,17 +6040,17 @@
 			"license": "ISC"
 		},
 		"node_modules/inquirer": {
-			"version": "8.2.6",
-			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
-			"integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
+			"version": "8.2.7",
+			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.7.tgz",
+			"integrity": "sha512-UjOaSel/iddGZJ5xP/Eixh6dY1XghiBw4XK13rCCIJcJfyhhoul/7KhLLUGtebEj6GDYM6Vnx/mVsjx2L/mFIA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@inquirer/external-editor": "^1.0.0",
 				"ansi-escapes": "^4.2.1",
 				"chalk": "^4.1.1",
 				"cli-cursor": "^3.1.0",
 				"cli-width": "^3.0.0",
-				"external-editor": "^3.0.3",
 				"figures": "^3.0.0",
 				"lodash": "^4.17.21",
 				"mute-stream": "0.0.8",
@@ -6907,9 +6838,9 @@
 			"license": "MIT"
 		},
 		"node_modules/jsonfile": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+			"integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7484,9 +7415,9 @@
 			"license": "MIT"
 		},
 		"node_modules/msw": {
-			"version": "2.10.2",
-			"resolved": "https://registry.npmjs.org/msw/-/msw-2.10.2.tgz",
-			"integrity": "sha512-RCKM6IZseZQCWcSWlutdf590M8nVfRHG1ImwzOtwz8IYxgT4zhUO0rfTcTvDGiaFE0Rhcc+h43lcF3Jc9gFtwQ==",
+			"version": "2.10.5",
+			"resolved": "https://registry.npmjs.org/msw/-/msw-2.10.5.tgz",
+			"integrity": "sha512-0EsQCrCI1HbhpBWd89DvmxY6plmvrM96b0sCIztnvcNHQbXn5vqwm1KlXslo6u4wN9LFGLC1WFjjgljcQhe40A==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8127,23 +8058,23 @@
 			}
 		},
 		"node_modules/orval": {
-			"version": "7.10.0",
-			"resolved": "https://registry.npmjs.org/orval/-/orval-7.10.0.tgz",
-			"integrity": "sha512-R1TlDDgK82dHfTXG0IuaIXHOrk6HQ1CuGejQQpQW9mBSCQA84AInp8U4Ovxw3upjMFNhghE8OlAQqD0ES8GgHQ==",
+			"version": "7.11.2",
+			"resolved": "https://registry.npmjs.org/orval/-/orval-7.11.2.tgz",
+			"integrity": "sha512-Cjc/dgnQwAOkvymzvPpFqFc2nQwZ29E+ZFWUI8yKejleHaoFKIdwvkM/b1njtLEjePDcF0hyqXXCTz2wWaXLig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@apidevtools/swagger-parser": "^10.1.1",
-				"@orval/angular": "7.10.0",
-				"@orval/axios": "7.10.0",
-				"@orval/core": "7.10.0",
-				"@orval/fetch": "7.10.0",
-				"@orval/hono": "7.10.0",
-				"@orval/mcp": "7.10.0",
-				"@orval/mock": "7.10.0",
-				"@orval/query": "7.10.0",
-				"@orval/swr": "7.10.0",
-				"@orval/zod": "7.10.0",
+				"@orval/angular": "7.11.2",
+				"@orval/axios": "7.11.2",
+				"@orval/core": "7.11.2",
+				"@orval/fetch": "7.11.2",
+				"@orval/hono": "7.11.2",
+				"@orval/mcp": "7.11.2",
+				"@orval/mock": "7.11.2",
+				"@orval/query": "7.11.2",
+				"@orval/swr": "7.11.2",
+				"@orval/zod": "7.11.2",
 				"ajv": "^8.17.1",
 				"cac": "^6.7.14",
 				"chalk": "^4.1.2",
@@ -8156,8 +8087,8 @@
 				"openapi3-ts": "4.2.2",
 				"string-argv": "^0.3.2",
 				"tsconfck": "^2.0.1",
-				"typedoc": "^0.28.0",
-				"typedoc-plugin-markdown": "^4.4.2",
+				"typedoc": "^0.28.7",
+				"typedoc-plugin-markdown": "^4.8.0",
 				"typescript": "^5.6.3"
 			},
 			"bin": {
@@ -8262,16 +8193,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/outvariant": {
@@ -9739,12 +9660,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/spawn-command": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/spawn-command/-/spawn-command-0.0.2.tgz",
-			"integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
-			"dev": true
-		},
 		"node_modules/spdx-correct": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -10046,9 +9961,9 @@
 			}
 		},
 		"node_modules/strtok3": {
-			"version": "10.3.1",
-			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
-			"integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
+			"version": "10.3.4",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
+			"integrity": "sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10154,9 +10069,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10285,19 +10200,6 @@
 				"node": ">=14.0.0"
 			}
 		},
-		"node_modules/tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"os-tmpdir": "~1.0.2"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10321,12 +10223,13 @@
 			}
 		},
 		"node_modules/token-types": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
-			"integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+			"version": "6.1.1",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.1.tgz",
+			"integrity": "sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
+				"@borewit/text-codec": "^0.1.0",
 				"@tokenizer/token": "^0.3.0",
 				"ieee754": "^1.2.1"
 			},
@@ -10508,17 +10411,17 @@
 			}
 		},
 		"node_modules/typedoc": {
-			"version": "0.28.2",
-			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.2.tgz",
-			"integrity": "sha512-9Giuv+eppFKnJ0oi+vxqLM817b/IrIsEMYgy3jj6zdvppAfDqV3d6DXL2vXUg2TnlL62V48th25Zf/tcQKAJdg==",
+			"version": "0.28.10",
+			"resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.10.tgz",
+			"integrity": "sha512-zYvpjS2bNJ30SoNYfHSRaFpBMZAsL7uwKbWwqoCNFWjcPnI3e/mPLh2SneH9mX7SJxtDpvDgvd9/iZxGbo7daw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@gerrit0/mini-shiki": "^3.2.2",
+				"@gerrit0/mini-shiki": "^3.9.0",
 				"lunr": "^2.3.9",
 				"markdown-it": "^14.1.0",
 				"minimatch": "^9.0.5",
-				"yaml": "^2.7.1"
+				"yaml": "^2.8.0"
 			},
 			"bin": {
 				"typedoc": "bin/typedoc"
@@ -10528,13 +10431,13 @@
 				"pnpm": ">= 10"
 			},
 			"peerDependencies": {
-				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+				"typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
 			}
 		},
 		"node_modules/typedoc-plugin-markdown": {
-			"version": "4.6.2",
-			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.6.2.tgz",
-			"integrity": "sha512-JVCIoK7FDN3t3PSLkwDyrBFyjtDznqDCJotP9evxhLyb6bEZTqhAGB0tPy1RmgHuY2WoAONMrsWs8LfLsD+A6A==",
+			"version": "4.8.1",
+			"resolved": "https://registry.npmjs.org/typedoc-plugin-markdown/-/typedoc-plugin-markdown-4.8.1.tgz",
+			"integrity": "sha512-ug7fc4j0SiJxSwBGLncpSo8tLvrT9VONvPUQqQDTKPxCoFQBADLli832RGPtj6sfSVJebNSrHZQRUdEryYH/7g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10545,9 +10448,9 @@
 			}
 		},
 		"node_modules/typedoc/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+			"integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10571,9 +10474,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"version": "5.9.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+			"integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -10605,9 +10508,9 @@
 			}
 		},
 		"node_modules/uint8array-extras": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
-			"integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.1.tgz",
+			"integrity": "sha512-+NWHrac9dvilNgme+gP4YrBSumsaMZP0fNBtXXFIf33RLLKEcBUKaQZ7ULUbS0sBfcjxIZ4V96OTRkCbM7hxpw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10637,9 +10540,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-			"integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+			"version": "7.10.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+			"integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
 			"license": "MIT"
 		},
 		"node_modules/universalify": {
@@ -11201,9 +11104,9 @@
 			}
 		},
 		"node_modules/yaml": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
-			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -11326,21 +11229,12 @@
 			}
 		},
 		"node_modules/zod": {
-			"version": "3.25.67",
-			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-			"integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
-			}
-		},
-		"node_modules/zod-to-json-schema": {
-			"version": "3.24.5",
-			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-			"integrity": "sha512-/AuWwMP+YqiPbsJx5D6TfgRTc4kTLjsh5SOcd4bLsfUg2RcEXrFMJl1DGgdHy2aCfsIA/cr/1JM0xcB2GZji8g==",
-			"license": "ISC",
-			"peerDependencies": {
-				"zod": "^3.24.1"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -22,29 +22,29 @@
 		"touchdesigner-mcp-server": "dist/cli.js"
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.13.2",
+		"@modelcontextprotocol/sdk": "^1.17.3",
 		"@mozilla/readability": "^0.6.0",
 		"@types/axios": "^0.14.4",
 		"@types/ws": "^8.18.1",
 		"@types/yargs": "^17.0.33",
-		"axios": "^1.10.0",
-		"zod": "^3.25.67"
+		"axios": "^1.11.0",
+		"zod": "3.25.76"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "2.0.6",
-		"@openapitools/openapi-generator-cli": "^2.21.0",
+		"@biomejs/biome": "2.2.0",
+		"@openapitools/openapi-generator-cli": "^2.22.0",
 		"@types/jsdom": "^21.1.7",
-		"@types/node": "^24.0.7",
+		"@types/node": "^24.3.0",
 		"@vitest/coverage-v8": "^3.2.4",
 		"archiver": "^7.0.1",
-		"msw": "^2.10.2",
+		"msw": "^2.10.5",
 		"mustache": "^4.2.0",
 		"npm-run-all": "^4.1.5",
-		"orval": "^7.10.0",
+		"orval": "^7.11.2",
 		"shx": "^0.4.0",
-		"typescript": "^5.8.3",
+		"typescript": "^5.9.2",
 		"vitest": "^3.2.4",
-		"yaml": "^2.8.0"
+		"yaml": "^2.8.1"
 	},
 	"type": "module",
 	"exports": {

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -7,7 +7,7 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.10.2'
+const PACKAGE_VERSION = '2.10.5'
 const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/src/api/customInstance.ts
+++ b/src/api/customInstance.ts
@@ -13,7 +13,7 @@ export const customInstance = <T>(
 		cancelToken: source.token,
 	}).then(({ data }) => data);
 
-	// @ts-ignore
+	// @ts-expect-error
 	promise.cancel = () => {
 		source.cancel("Query was cancelled");
 	};


### PR DESCRIPTION
This pull request primarily updates dependencies and development tools to their latest versions, along with minor configuration improvements and a TypeScript annotation fix. These changes help keep the project up-to-date, improve compatibility, and maintain code quality.

Dependency and tool updates:

* Updated multiple dependencies and devDependencies in `package.json`, including `@modelcontextprotocol/sdk`, `axios`, `zod`, `@biomejs/biome`, `typescript`, and others, to their latest versions for improved stability and feature support.
* Updated the `msw` package version in both `package.json` and the `public/mockServiceWorker.js` file to `2.10.5` for better mocking support. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R47) [[2]](diffhunk://#diff-9b67b1564153a29cf70395735ad6a98050c0b64868ca3f7c8feafe8bc6cf8f52L10-R10)

Configuration improvements:

* Updated the `$schema` version in `biome.json` from `2.0.6` to `2.2.0` and reformatted the `assist` section for improved configuration clarity and compatibility with the latest Biome tooling. [[1]](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L2-R2) [[2]](diffhunk://#diff-2bc8a1f5e9380d5a187a4e90f11b4dd36c3abad6aea44c84be354a4f44cdec55L43-R49)

TypeScript annotation fix:

* Replaced a `@ts-ignore` directive with `@ts-expect-error` in `src/api/customInstance.ts` to make TypeScript error suppression more explicit and maintainable.