### PR TITLE
[issue 106] Migrate from DXT to MCPB: update workflows, documentation…

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -30,14 +30,14 @@ jobs:
       - run: npm run gen
       - run: npm run lint
       - run: npm run test:unit
-      - name: Test DXT package build
+      - name: Test MCPB package build
         run: |
-          # Install DXT CLI tool
-          npm install -g @anthropic-ai/dxt
+          # Install MCPB CLI tool
+          npm install -g @anthropic-ai/mcpb
 
-          # Build DXT package to ensure it works
+          # Build MCPB package to ensure it works
           npm run build:dist
-          npm run build:dxt
+          npm run build:mcpb
 
-          echo "DXT package build test completed!"
-          ls -la *.dxt
+          echo "MCPB package build test completed!"
+          ls -la *.mcpb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,13 @@ jobs:
           cd temp_td && zip -r ../touchdesigner-mcp-td.zip .
           rm -rf temp_td
           echo "Build artifacts extracted and package created!"
-      - name: Build DXT package
+      - name: Build MCPB package
         run: |
-          # Build DXT package
-          npm run build:dxt
+          # Build MCPB package
+          npm run build:mcpb
 
-          echo "DXT package created successfully!"
-          ls -la *.dxt
+          echo "MCPB package created successfully!"
+          ls -la *.mcpb
       - name: Get Node.js project information
         id: projectinfo
         uses: gregoranders/nodejs-project-info@master
@@ -87,18 +87,18 @@ jobs:
           body: |
             ## Downloads
             - **TouchDesigner Components**: [touchdesigner-mcp-td.zip](https://github.com/${{ github.repository }}/releases/download/v${{ steps.projectinfo.outputs.version }}/touchdesigner-mcp-td.zip)
-            - **Desktop Extension (.dxt)**: [touchdesigner-mcp.dxt](https://github.com/${{ github.repository }}/releases/download/v${{ steps.projectinfo.outputs.version }}/touchdesigner-mcp.dxt)
+            - **MCP Bundle (.mcpb)**: [touchdesigner-mcp.mcpb](https://github.com/${{ github.repository }}/releases/download/v${{ steps.projectinfo.outputs.version }}/touchdesigner-mcp.mcpb)
 
             ## Usage
 
-            ### Quick Start with Claude Desktop and Desktop Extension (Recommended)
-            1. Download `TouchDesigner Components` and the `Desktop Extension`.
+            ### Quick Start with Claude Desktop and MCP Bundle (Recommended)
+            1. Download `TouchDesigner Components` and the `MCP Bundle`.
             2. Extract the TouchDesigner components from `touchdesigner-mcp-td.zip`.
             3. Import `mcp_webserver_base.tox` into your TouchDesigner project.
 
             https://github.com/user-attachments/assets/215fb343-6ed8-421c-b948-2f45fb819ff4
 
-            4. Install the extension in Claude Desktop by double-clicking the `touchdesigner-mcp.dxt` file.
+            4. Install the bundle in Claude Desktop by double-clicking the `touchdesigner-mcp.mcpb` file.
 
             https://github.com/user-attachments/assets/0786d244-8b82-4387-bbe4-9da048212854
 
@@ -123,7 +123,7 @@ jobs:
             ## Changes
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for a detailed history of changes.
           files: |
-            touchdesigner-mcp.dxt
+            touchdesigner-mcp.mcpb
             touchdesigner-mcp-td.zip
           draft: false
           prerelease: ${{ steps.prerelease.outputs.is_prerelease == 'true' }}

--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ src/gen
 .venv
 .actrc
 *.dxt
+*.mcpb
 *.pem
 td/modules/td_server
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-11-18
+
+### Changed
+
+- **DXT to MCPB Migration**: Migrated from Desktop Extensions (DXT) to [MCP Bundles](https://github.com/modelcontextprotocol/mcpb) (MCPB)
+  - Updated manifest from `dxt_version: "0.1"` to `manifest_version: "0.3"`
+  - Renamed `.dxt` extension to `.mcpb`
+  - Updated build scripts and workflows to use `@anthropic-ai/mcpb` CLI
+  - Enhanced manifest.json with new MCPB features (repository structure)
+  - Updated all documentation to reflect MCPB terminology
+  - Changed build script from `build:dxt` to `build:mcpb`
+  - Updated GitHub Actions workflows for MCPB package creation
+  - Updated README.md and README.ja.md with new installation instructions
+
+### Migration Notes
+
+For users upgrading from previous versions:
+
+- Uninstall the old `.dxt` extension from Claude Desktop
+- Download and install the new `.mcpb` bundle from the latest release
+- No changes required to TouchDesigner components
+- All existing functionality remains unchanged
+
 ## [1.1.2] - 2025-11-16
 
 ### Fixed

--- a/README.ja.md
+++ b/README.ja.md
@@ -52,14 +52,14 @@ flowchart LR
 ## 利用方法
 
 <details>
-  <summary>方法1: Claude Desktop + Desktop Extensions（推奨）</summary>
+  <summary>方法1: Claude Desktop + MCP Bundle（推奨）</summary>
 
 ##### 1. ファイルをダウンロード
 
 [リリースページ](https://github.com/8beeeaaat/touchdesigner-mcp/releases/latest)から以下をダウンロード：
 
 - **TouchDesigner Components**: `touchdesigner-mcp-td.zip`
-- **Desktop Extensions (.dxt)**: `touchdesigner-mcp.dxt`
+- **[MCP Bundle](https://github.com/modelcontextprotocol/mcpb) (.mcpb)**: `touchdesigner-mcp.mcpb`
 
 ##### 2. TouchDesignerコンポーネントを設置
 
@@ -73,13 +73,13 @@ flowchart LR
 
   ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
 
-##### 3. Desktop Extensionをインストール
+##### 3. MCP Bundleをインストール
 
-`touchdesigner-mcp.dxt`ファイルをダブルクリックしてClaude Desktopに拡張機能をインストール
+`touchdesigner-mcp.mcpb`ファイルをダブルクリックしてClaude DesktopにMCP Bundleをインストール
 
 <https://github.com/user-attachments/assets/0786d244-8b82-4387-bbe4-9da048212854>
 
-##### 4. 拡張機能が自動的にTouchDesignerサーバー接続を処理
+##### 4. MCP Bundleが自動的にTouchDesignerサーバー接続を処理
 
 **⚠️ 重要:** TouchDesignerコンポーネントのディレクトリ構造は展開した状態を正確に保持してください。`mcp_webserver_base.tox`コンポーネントは`modules/`ディレクトリやその他のファイルへの相対パスを参照しています。
 

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ flowchart LR
 ## Usage
 
 <details>
-  <summary>Method 1: Using Claude Desktop and Desktop Extensions (Recommended)</summary>
+  <summary>Method 1: Using Claude Desktop and MCP Bundle (Recommended)</summary>
 
 ### 1. Download Files
 
 Download the following from the [releases page](https://github.com/8beeeaaat/touchdesigner-mcp/releases/latest):
 
 - **TouchDesigner Components**: `touchdesigner-mcp-td.zip`
-- **Desktop Extension (.dxt)**: `touchdesigner-mcp.dxt`
+- **[MCP Bundle](https://github.com/modelcontextprotocol/mcpb) (.mcpb)**: `touchdesigner-mcp.mcpb`
 
 ### 2. Set up TouchDesigner Components
 
@@ -73,15 +73,15 @@ Download the following from the [releases page](https://github.com/8beeeaaat/tou
 
   ![import](https://github.com/8beeeaaat/touchdesigner-mcp/blob/main/assets/textport.png)
 
-### 3. Install the Desktop Extension
+### 3. Install the MCP Bundle
 
-Double-click the `touchdesigner-mcp.dxt` file to install the extension in Claude Desktop.
+Double-click the `touchdesigner-mcp.mcpb` file to install the bundle in Claude Desktop.
 
 <https://github.com/user-attachments/assets/0786d244-8b82-4387-bbe4-9da048212854>
 
 ### 4. Connect to the Server
 
-The extension will automatically handle the connection to the TouchDesigner server.
+The MCP bundle will automatically handle the connection to the TouchDesigner server.
 
 **⚠️ Important:** The directory structure must be preserved exactly as extracted. The `mcp_webserver_base.tox` component references relative paths to the `modules/` directory and other files.
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,12 +1,16 @@
 {
-  "dxt_version": "0.1",
+  "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",
   "author": {
     "name": "8beeeaaat",
+    "url": "https://github.com/8beeeaaat/touchdesigner-mcp"
+  },
+  "repository": {
+    "type": "git",
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp"
   },
   "server": {
@@ -95,12 +99,15 @@
     }
   },
   "compatibility": {
+    "claude_desktop": ">=1.0.0",
     "platforms": [
-      "win32",
       "darwin",
+      "win32",
       "linux"
     ],
-    "node_version": ">=18.0.0"
+    "runtimes": {
+      "node": ">=18.0.0"
+    }
   },
   "keywords": [
     "touchdesigner",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.1.2",
+			"version": "1.2.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",
@@ -63,7 +63,7 @@
 		"build": "run-s build:*",
 		"build:gen": "npm run gen",
 		"build:dist": "tsc && shx chmod +x dist/*.js && shx cp -r src/features/tools/presenter/templates dist/features/tools/presenter/",
-		"build:dxt": "npx @anthropic-ai/dxt pack dxt/ touchdesigner-mcp.dxt",
+		"build:mcpb": "npx @anthropic-ai/mcpb pack mcpb/ touchdesigner-mcp.mcpb",
 		"lint": "run-p lint:*",
 		"lint:biome": "biome check",
 		"lint:tsc": "tsc --noEmit",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { TouchDesignerServer } from "./server/touchDesignerServer.js";
 
-// Note: Environment variables should be set by the Desktop Extensions runtime or CLI arguments
+// Note: Environment variables should be set by the MCP Bundle runtime or CLI arguments
 
 const DEFAULT_HOST = "http://127.0.0.1";
 const DEFAULT_PORT = 9981;


### PR DESCRIPTION
- close https://github.com/8beeeaaat/touchdesigner-mcp/issues/106 (cc @jeffcrouse)

This pull request migrates the project from the old Desktop Extension (DXT) format to the new [MCP Bundle (MCPB)](https://github.com/modelcontextprotocol/mcpb) format for Claude Desktop integration. The migration includes renaming file extensions, updating build scripts and GitHub Actions workflows, enhancing the manifest structure, and revising documentation to reflect the new terminology and installation process. No changes are required for TouchDesigner components, and all existing functionality remains unchanged.

**Migration to MCP Bundle format:**

* Renamed all references and artifacts from `.dxt` (Desktop Extension) to `.mcpb` (MCP Bundle), including build outputs, workflow steps, and release assets. (`.github/workflows/development.yml` [[1]](diffhunk://#diff-73aefd4c5a252c08017de5edafa094a95ee6031e37832d96a4ff247563a57833L33-R43) `.github/workflows/release.yml` [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R60) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L90-R101) [[4]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L126-R126)
* Updated build scripts and dependencies to use `@anthropic-ai/mcpb` CLI instead of `@anthropic-ai/dxt`, and changed the relevant npm script from `build:dxt` to `build:mcpb`. (`package.json` [package.jsonL66-R66](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L66-R66))

**Manifest and metadata enhancements:**

* Migrated manifest from `dxt/manifest.json` to `mcpb/manifest.json`, updating the version field, manifest schema, and adding repository and compatibility information. (`mcpb/manifest.json` [[1]](diffhunk://#diff-dddadaf6473d0814b4cf83e615563f7a12740b9815cc9e45d09b25cfcf88a52cL2-R15) [[2]](diffhunk://#diff-dddadaf6473d0814b4cf83e615563f7a12740b9815cc9e45d09b25cfcf88a52cR102-R111)
* Updated project and manifest versions to `1.2.0` to mark the migration. (`package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) `mcpb/manifest.json` [[2]](diffhunk://#diff-dddadaf6473d0814b4cf83e615563f7a12740b9815cc9e45d09b25cfcf88a52cL2-R15)

**Documentation updates:**

* Revised all documentation (`README.md`, `README.ja.md`) to use MCP Bundle terminology, update installation instructions, and clarify the migration process for users. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-R62) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R84) `README.ja.md` [[3]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L55-R62) [[4]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L76-R82)
* Added migration notes and details to the changelog for version `1.2.0`, including user instructions for upgrading from DXT to MCPB. (`CHANGELOG.md` [CHANGELOG.mdR8-R30](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R30))

**Minor code and comment updates:**

* Updated comments in `src/cli.ts` to reference MCP Bundle runtime instead of Desktop Extensions. (`src/cli.ts` [src/cli.tsL6-R6](diffhunk://#diff-fa8d4e24d8399e8350f1c8bad05df53e8032ea995835bf911507015e2db61cddL6-R6))