### PR TITLE
Refactor ILogger interface and McpLogger implementation

### DIFF
--- a/scripts/formatPreview.ts
+++ b/scripts/formatPreview.ts
@@ -34,10 +34,17 @@ class MockMcpServer {
 }
 
 const logger: ILogger = {
-	debug: () => {},
-	error: console.error,
-	log: () => {},
-	warn: console.warn,
+	sendLog: ({ level, data }) => {
+		if (level === "error") {
+			console.error(data);
+			return;
+		}
+		if (level === "warning") {
+			console.warn(data);
+			return;
+		}
+		console.log(data);
+	},
 };
 
 async function callTool(

--- a/scripts/showDetailedNodes.ts
+++ b/scripts/showDetailedNodes.ts
@@ -36,10 +36,17 @@ class MockMcpServer {
 }
 
 const logger: ILogger = {
-	debug: () => {},
-	error: console.error,
-	log: () => {},
-	warn: console.warn,
+	sendLog: ({ level, data }) => {
+		if (level === "error") {
+			console.error(data);
+			return;
+		}
+		if (level === "warning") {
+			console.warn(data);
+			return;
+		}
+		console.log(data);
+	},
 };
 
 async function callTool(tool: ToolEntry, params?: Record<string, unknown>) {

--- a/src/core/errorHandling.ts
+++ b/src/core/errorHandling.ts
@@ -27,7 +27,25 @@ export function handleToolError(
 			? error
 			: new Error(error === null ? "Null error received" : String(error));
 
-	logger.error(toolName, formattedError);
+	const logData: Record<string, unknown> = {
+		error: formattedError.message,
+		message: "Tool execution failed",
+		toolName,
+	};
+
+	if (referenceComment) {
+		logData.referenceComment = referenceComment;
+	}
+
+	if (formattedError.stack) {
+		logData.stack = formattedError.stack;
+	}
+
+	logger.sendLog({
+		data: logData,
+		level: "error",
+		logger: "ErrorHandling",
+	});
 
 	const errorMessage = `${toolName}: ${formattedError}${referenceComment ? `. ${referenceComment}` : ""}`;
 

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,17 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { LoggingMessageNotification } from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * Logger interface definition
  */
 export interface ILogger {
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	log(...args: any[]): void;
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	debug(...args: any[]): void;
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	warn(...args: any[]): void;
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	error(...args: any[]): void;
+	sendLog(args: LoggingMessageNotification["params"]): void;
 }
 
 /**
@@ -21,47 +15,19 @@ export interface ILogger {
 export class McpLogger implements ILogger {
 	constructor(private server: McpServer) {}
 
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	public log(...args: any[]): void {
-		this.sendLog("info", args);
-	}
-
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	public debug(...args: any[]): void {
-		this.sendLog("debug", args);
-	}
-
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	public warn(...args: any[]): void {
-		this.sendLog("warning", args);
-	}
-
-	// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-	public error(...args: any[]): void {
-		this.sendLog("error", args);
-	}
-
-	private sendLog(
-		level: "info" | "debug" | "warning" | "error",
-		// biome-ignore lint/suspicious/noExplicitAny: logging accepts any type
-		args: any[],
-	): void {
-		for (const arg of args) {
-			try {
-				this.server.server.sendLoggingMessage({
-					data: arg,
-					level,
-				});
-			} catch (error) {
-				if (error instanceof Error && error.message === "Not connected") {
-					return;
-				}
-
-				console.error(
-					`Failed to send log to MCP server: ${error instanceof Error ? error.message : String(error)}`,
-				);
-				console[level === "warning" ? "warn" : level]?.(arg);
+	sendLog(args: LoggingMessageNotification["params"]) {
+		try {
+			this.server.server.sendLoggingMessage({
+				...args,
+			});
+		} catch (error) {
+			if (error instanceof Error && error.message === "Not connected") {
+				return;
 			}
+
+			console.error(
+				`Failed to send log to MCP server: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
 	}
 }

--- a/src/features/prompts/handlers/td_prompts.ts
+++ b/src/features/prompts/handlers/td_prompts.ts
@@ -57,7 +57,10 @@ export function registerTdPrompts(server: McpServer, logger: ILogger): void {
 
 	server.server.setRequestHandler(GetPromptRequestSchema, (request) => {
 		try {
-			logger.debug(`Handling GetPromptRequest: ${request.params.name}`);
+			logger.sendLog({
+				data: `Handling GetPromptRequest: ${request.params.name}`,
+				level: "debug",
+			});
 			const prompt = getPrompt(request.params.name);
 			if (!prompt) {
 				throw new Error("Prompt name is required");
@@ -97,7 +100,10 @@ export function registerTdPrompts(server: McpServer, logger: ILogger): void {
 		} catch (error) {
 			const errorMessage =
 				error instanceof Error ? error.message : String(error);
-			logger.error(`Error handling prompt request: ${errorMessage}`);
+			logger.sendLog({
+				data: `Error handling prompt request: ${errorMessage}`,
+				level: "error",
+			});
 			throw new Error(errorMessage);
 		}
 	});

--- a/src/features/tools/handlers/tdTools.ts
+++ b/src/features/tools/handlers/tdTools.ts
@@ -183,7 +183,10 @@ export function registerTdTools(
 		async (params: ExecPythonScriptToolParams) => {
 			try {
 				const { detailLevel, responseFormat, ...scriptParams } = params;
-				logger.debug(`Executing script: ${scriptParams.script}`);
+				logger.sendLog({
+					data: `Executing script: ${scriptParams.script}`,
+					level: "debug",
+				});
 
 				const result = await tdClient.execPythonScript(scriptParams);
 				if (!result.success) {
@@ -419,7 +422,10 @@ export function registerTdTools(
 					],
 				};
 			} catch (error) {
-				logger.error(error);
+				logger.sendLog({
+					data: error,
+					level: "error",
+				});
 				return handleToolError(
 					error,
 					logger,

--- a/src/server/connectionManager.ts
+++ b/src/server/connectionManager.ts
@@ -22,16 +22,20 @@ export class ConnectionManager {
 	 */
 	async connect(transport: Transport): Promise<Result<void, Error>> {
 		if (this.isConnected()) {
-			this.logger.log("MCP server already connected");
+			this.logger.sendLog({
+				data: "MCP server already connected",
+				level: "info",
+			});
 			return createSuccessResult(undefined);
 		}
 
 		this.transport = transport;
 		try {
 			await this.server.connect(transport);
-			this.logger.log(
-				`Server connected and ready to process requests: ${process.env.TD_WEB_SERVER_HOST}:${process.env.TD_WEB_SERVER_PORT}`,
-			);
+			this.logger.sendLog({
+				data: `Server connected and ready to process requests: ${process.env.TD_WEB_SERVER_HOST}:${process.env.TD_WEB_SERVER_PORT}`,
+				level: "info",
+			});
 
 			// Connection will be checked when tools are actually used
 			const connectionResult = await this.checkTDConnection();
@@ -40,7 +44,10 @@ export class ConnectionManager {
 					`Failed to connect to TouchDesigner. The mcp_webserver_base on TouchDesigner not currently available: ${connectionResult.error.message}`,
 				);
 			}
-			this.logger.log("TouchDesigner connection verified");
+			this.logger.sendLog({
+				data: "TouchDesigner connection verified",
+				level: "info",
+			});
 			return createSuccessResult(undefined);
 		} catch (error) {
 			this.transport = null;
@@ -85,7 +92,10 @@ export class ConnectionManager {
 	 * Check connection to TouchDesigner
 	 */
 	private async checkTDConnection(): Promise<Result<unknown, Error>> {
-		this.logger.log("Testing connection to TouchDesigner server...");
+		this.logger.sendLog({
+			data: "Testing connection to TouchDesigner server...",
+			level: "info",
+		});
 		try {
 			const result = await this.tdClient.getTdInfo();
 			if (!result.success) {

--- a/src/tdClient/touchDesignerClient.ts
+++ b/src/tdClient/touchDesignerClient.ts
@@ -77,10 +77,7 @@ export type Result<T, E = Error> = SuccessResult<T> | ErrorResult<E>;
  * Null logger implementation that discards all logs
  */
 const nullLogger: ILogger = {
-	debug: () => {},
-	error: () => {},
-	log: () => {},
-	warn: () => {},
+	sendLog: () => {},
 };
 
 /**
@@ -122,6 +119,15 @@ export class TouchDesignerClient {
 	private readonly logger: ILogger;
 	private readonly api: ITouchDesignerApi;
 
+	private logDebug(message: string, context?: Record<string, unknown>) {
+		const data = context ? { message, ...context } : { message };
+		this.logger.sendLog({
+			data,
+			level: "debug",
+			logger: "TouchDesignerClient",
+		});
+	}
+
 	/**
 	 * Initialize TouchDesigner client with optional dependencies
 	 */
@@ -143,9 +149,10 @@ export class TouchDesignerClient {
 			result: unknown;
 		}>,
 	>(params: ExecNodeMethodRequest) {
-		this.logger.debug(
-			`Executing node method: ${params.method} on ${params.nodePath}`,
-		);
+		this.logDebug("Executing node method", {
+			method: params.method,
+			nodePath: params.nodePath,
+		});
 
 		const result = await this.api.execNodeMethod(params);
 		return handleApiResponse<DATA>(result as TdResponse<DATA>);
@@ -159,7 +166,7 @@ export class TouchDesignerClient {
 			result: unknown;
 		},
 	>(params: ExecPythonScriptRequest) {
-		this.logger.debug(`Executing Python script: ${params}`);
+		this.logDebug("Executing Python script", { params });
 		const result = await this.api.execPythonScript(params);
 		return handleApiResponse<DATA>(result as TdResponse<DATA>);
 	}
@@ -168,7 +175,7 @@ export class TouchDesignerClient {
 	 * Get TouchDesigner server information
 	 */
 	async getTdInfo() {
-		this.logger.debug("Getting server info");
+		this.logDebug("Getting server info");
 		const result = await this.api.getTdInfo();
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -177,7 +184,9 @@ export class TouchDesignerClient {
 	 * Get list of nodes
 	 */
 	async getNodes(params: GetNodesParams) {
-		this.logger.debug(`Getting nodes for parent: ${params.parentPath}`);
+		this.logDebug("Getting nodes for parent", {
+			parentPath: params.parentPath,
+		});
 		const result = await this.api.getNodes(params);
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -186,7 +195,9 @@ export class TouchDesignerClient {
 	 * Get node properties
 	 */
 	async getNodeDetail(params: GetNodeDetailParams) {
-		this.logger.debug(`Getting properties for node: ${params.nodePath}`);
+		this.logDebug("Getting properties for node", {
+			nodePath: params.nodePath,
+		});
 		const result = await this.api.getNodeDetail(params);
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -195,9 +206,11 @@ export class TouchDesignerClient {
 	 * Create a new node
 	 */
 	async createNode(params: CreateNodeRequest) {
-		this.logger.debug(
-			`Creating node: ${params.nodeName} of type ${params.nodeType} under ${params.parentPath}`,
-		);
+		this.logDebug("Creating node", {
+			nodeName: params.nodeName,
+			nodeType: params.nodeType,
+			parentPath: params.parentPath,
+		});
 		const result = await this.api.createNode(params);
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -206,7 +219,7 @@ export class TouchDesignerClient {
 	 * Update node properties
 	 */
 	async updateNode(params: UpdateNodeRequest) {
-		this.logger.debug(`Updating node: ${params.nodePath}`);
+		this.logDebug("Updating node", { nodePath: params.nodePath });
 		const result = await this.api.updateNode(params);
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -215,7 +228,7 @@ export class TouchDesignerClient {
 	 * Delete a node
 	 */
 	async deleteNode(params: DeleteNodeParams) {
-		this.logger.debug(`Deleting node: ${params.nodePath}`);
+		this.logDebug("Deleting node", { nodePath: params.nodePath });
 		const result = await this.api.deleteNode(params);
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -224,7 +237,7 @@ export class TouchDesignerClient {
 	 * Get list of available Python classes/modules in TouchDesigner
 	 */
 	async getClasses() {
-		this.logger.debug("Getting Python classes");
+		this.logDebug("Getting Python classes");
 		const result = await this.api.getTdPythonClasses();
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}
@@ -233,7 +246,7 @@ export class TouchDesignerClient {
 	 * Get details of a specific class/module
 	 */
 	async getClassDetails(className: string) {
-		this.logger.debug(`Getting class details for: ${className}`);
+		this.logDebug("Getting class details", { className });
 		const result = await this.api.getTdPythonClassDetails(className);
 		return handleApiResponse<(typeof result)["data"]>(result);
 	}

--- a/tests/integration/mcpToolsResponse.test.ts
+++ b/tests/integration/mcpToolsResponse.test.ts
@@ -26,10 +26,7 @@ class MockMcpServer {
 }
 
 const logger: ILogger = {
-	debug: () => {},
-	error: () => {},
-	log: () => {},
-	warn: () => {},
+	sendLog: () => {},
 };
 
 function createMockTdClient(): TouchDesignerClient {

--- a/tests/unit/connectionManager.test.ts
+++ b/tests/unit/connectionManager.test.ts
@@ -20,10 +20,7 @@ const mockServer = {
 } as unknown as McpServer;
 
 const mockLogger = {
-	debug: vi.fn(),
-	error: vi.fn(),
-	log: vi.fn(),
-	warn: vi.fn(),
+	sendLog: vi.fn(),
 } as ILogger;
 
 const mockTdClient = {
@@ -74,9 +71,10 @@ describe("ConnectionManager", () => {
 			// Assert
 			expect(result.success).toBe(true);
 			expect(mockServer.connect).toHaveBeenCalledWith(mockTransport);
-			expect(mockLogger.log).toHaveBeenCalledWith(
-				"Server connected and ready to process requests: http://127.0.0.1:9981",
-			);
+			expect(mockLogger.sendLog).toHaveBeenCalledWith({
+				data: "Server connected and ready to process requests: http://127.0.0.1:9981",
+				level: "info",
+			});
 			expect(mockTdClient.getTdInfo).toHaveBeenCalled();
 			expect(connectionManager.isConnected()).toBe(true);
 		});
@@ -99,9 +97,10 @@ describe("ConnectionManager", () => {
 
 			// Assert
 			expect(result.success).toBe(true);
-			expect(mockLogger.log).toHaveBeenCalledWith(
-				"MCP server already connected",
-			);
+			expect(mockLogger.sendLog).toHaveBeenCalledWith({
+				data: "MCP server already connected",
+				level: "info",
+			});
 		});
 
 		it("should handle MCP server connection failure", async () => {

--- a/tests/unit/errorHandling.test.ts
+++ b/tests/unit/errorHandling.test.ts
@@ -5,17 +5,21 @@ import type { ILogger } from "../../src/core/logger.js";
 describe("errorHandling", () => {
 	describe("handleToolError", () => {
 		const mockLogger: ILogger = {
-			debug: vi.fn(),
-			error: vi.fn(),
-			log: vi.fn(),
-			warn: vi.fn(),
+			sendLog: vi.fn(),
 		};
 
 		it("should handle Error instance correctly", () => {
 			const error = new Error("Test error");
 			const result = handleToolError(error, mockLogger, "Operation failed");
 
-			expect(mockLogger.error).toHaveBeenCalledWith("Operation failed", error);
+			expect(mockLogger.sendLog).toHaveBeenCalledWith({
+				data: expect.objectContaining({
+					error: "Test error",
+					toolName: "Operation failed",
+				}),
+				level: "error",
+				logger: "ErrorHandling",
+			});
 			expect(result).toEqual({
 				content: [
 					{
@@ -31,7 +35,7 @@ describe("errorHandling", () => {
 			const error = "String error";
 			const result = handleToolError(error, mockLogger, "Operation failed");
 
-			expect(mockLogger.error).toHaveBeenCalled();
+			expect(mockLogger.sendLog).toHaveBeenCalled();
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain("String error");
 		});
@@ -40,7 +44,7 @@ describe("errorHandling", () => {
 			const error = null;
 			const result = handleToolError(error, mockLogger, "Operation failed");
 
-			expect(mockLogger.error).toHaveBeenCalled();
+			expect(mockLogger.sendLog).toHaveBeenCalled();
 			expect(result.isError).toBe(true);
 			expect(result.content[0].text).toContain("Null error received");
 		});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -13,7 +13,10 @@ describe("Logger", () => {
 			};
 
 			const logger = new McpLogger(mockServer as unknown as McpServer);
-			logger.log("test message");
+			logger.sendLog({
+				data: "test message",
+				level: "info",
+			});
 
 			expect(mockSendLoggingMessage).toHaveBeenCalledWith({
 				data: "test message",
@@ -34,7 +37,12 @@ describe("Logger", () => {
 
 			const logger = new McpLogger(mockServer as unknown as McpServer);
 
-			expect(() => logger.log("test message")).not.toThrow();
+			expect(() =>
+				logger.sendLog({
+					data: "test message",
+					level: "info",
+				}),
+			).not.toThrow();
 			expect(mockSendLoggingMessage).toHaveBeenCalled();
 		});
 	});

--- a/tests/unit/touchDesignerClient.mock.test.ts
+++ b/tests/unit/touchDesignerClient.mock.test.ts
@@ -23,10 +23,7 @@ vi.mock("../../src/gen/endpoints/TouchDesignerAPI", async () => {
 });
 
 const nullLogger: ILogger = {
-	debug: () => {},
-	error: () => {},
-	log: () => {},
-	warn: () => {},
+	sendLog: () => {},
 };
 
 describe("TouchDesignerClient with mocks", () => {
@@ -142,10 +139,7 @@ describe("TouchDesignerClient with mocks", () => {
 
 	test("TouchDesignerClient should accept custom logger", async () => {
 		const mockLogger: ILogger = {
-			debug: vi.fn(),
-			error: vi.fn(),
-			log: vi.fn(),
-			warn: vi.fn(),
+			sendLog: vi.fn(),
 		};
 
 		const mockResponse = {
@@ -165,7 +159,9 @@ describe("TouchDesignerClient with mocks", () => {
 		const result = await client.getTdInfo();
 
 		expect(result.success).toBe(true);
-		expect(mockLogger.debug).toHaveBeenCalled();
+		expect(mockLogger.sendLog).toHaveBeenCalledWith(
+			expect.objectContaining({ level: "debug" }),
+		);
 	});
 
 	test("TouchDesignerClient should accept custom httpClient", async () => {


### PR DESCRIPTION
Simplify the ILogger interface by consolidating logging methods into a single `sendLog` method. Update the McpLogger implementation to utilize this new method for logging messages at different levels. Adjust all relevant code to ensure consistent logging behavior throughout the application.