### PR TITLE
docs: update troubleshooting section for version compatibility

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -366,7 +366,7 @@ td/
 
 ### バージョン互換性のトラブルシューティング
 
-- `ConnectionManager.connect` の実行中、MCPサーバーは自身のバージョンと `getTdInfo` が報告するTouchDesigner APIサーバーのバージョンを比較します。APIサーバーがバージョンを公開していない場合、またはバージョンが異なる場合（例：片方のみが更新された場合）、MCPサーバーはClaude/Codexコンソールおよび TouchDesigner ログ DAT に説明的なエラーメッセージを表示して接続を中止します。
+- ツールが呼び出されると、MCPサーバーは自身のバージョンと `getTdInfo` が報告するTouchDesigner APIサーバーのバージョンを比較します。APIサーバーがバージョンを公開していない場合、またはバージョンが異なる場合（例：片方のみが更新された場合）、ツール呼び出しは失敗し、Claude/Codexコンソールおよび TouchDesigner ログ DAT に説明的なエラーメッセージが表示されます。
 - 不一致を解決するには、TouchDesignerコンポーネントを再インストールしてください：
   1. リリースページから最新の [touchdesigner-mcp-td.zip](https://github.com/8beeeaaat/touchdesigner-mcp/releases/latest/download/touchdesigner-mcp-td.zip) をダウンロードします。
   2. 既存の `touchdesigner-mcp-td` フォルダを削除し、新しく展開した内容に置き換えます。

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ The build process (`npm run build`) runs all necessary generation steps (`npm ru
 
 ### Troubleshooting version compatibility
 
-- During `ConnectionManager.connect` the MCP server compares its own version with the TouchDesigner API server version reported by `getTdInfo`. If the API server does not expose a version or the versions differ (for example because only one side was updated), the MCP server aborts the connection with a descriptive error message in the Claude/Codex console and in the TouchDesigner log DAT.
+- When any tool is called, the MCP server compares its own version with the TouchDesigner API server version reported by `getTdInfo`. If the API server does not expose a version or the versions differ (for example because only one side was updated), the tool call fails with a descriptive error message in the Claude/Codex console and in the TouchDesigner log DAT.
 - To resolve the mismatch, reinstall both the TouchDesigner components
   1. Download the latest [touchdesigner-mcp-td.zip](https://github.com/8beeeaaat/touchdesigner-mcp/releases/latest/download/touchdesigner-mcp-td.zip) from the releases page.
   2. Delete the existing \`touchdesigner-mcp-td\` folder and replace it with the newly extracted contents.


### PR DESCRIPTION
This pull request updates the documentation in both the English (`README.md`) and Japanese (`README.ja.md`) readme files to clarify how version compatibility checks are performed between the MCP server and the TouchDesigner API server. The changes make it clear that version checks now occur whenever any tool is called, rather than only during the connection process, and they explain how failures are reported.

Documentation updates:

* Updated the description of version compatibility checks to specify that the MCP server compares its version with the TouchDesigner API server version whenever any tool is called, not just during connection. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L369-R369) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L369-R369)
* Clarified that, in case of a version mismatch or missing version, the tool call fails and a descriptive error message is shown in both the Claude/Codex console and the TouchDesigner log DAT. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L369-R369) [[2]](diffhunk://#diff-b3fc642ee9795d9cb415501fb1ca7858d4222eb6f32ae8dc26ae29b3f1934336L369-R369)