### PR TITLE
Update GitHub Sponsors username in FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [8beeeaaat]


### PR DESCRIPTION
This pull request adds funding information to the repository by specifying a GitHub sponsor account in the `.github/FUNDING.yml` file.