### PR TITLE
fix: update MCP_HTTP_HOST binding in docker-compose and documentation for clarity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "6274:6274" # MCP inspector
       - "6277:6277" # MCP inspector proxy
-      - "${MCP_HTTP_PORT:-6280}:${MCP_HTTP_PORT:-6280}" # Streamable HTTP (optional)
+      - "127.0.0.1:${MCP_HTTP_PORT:-6280}:${MCP_HTTP_PORT:-6280}" # Streamable HTTP (optional, loopback-only by default)
     stdin_open: true
     tty: true
     restart: unless-stopped

--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -229,7 +229,7 @@ args = ["-y", "touchdesigner-mcp-server@latest", "--stdio"]
    }
    ```
 
-4. コンテナのヘルスチェックを実行して接続確認します。
+4. コンテナのヘルスチェックを実行して接続確認します（コンテナは `0.0.0.0` で待ち受けますが、`docker-compose.yml` で `127.0.0.1` に公開するためデフォルトではローカルのみ到達可能です）。
 
    ```bash
    curl http://localhost:6280/health
@@ -278,9 +278,11 @@ TouchDesigner MCP Server は stdio だけでなく HTTP/SSE でも動作しま�
 | オプション | 説明 | デフォルト |
 | --- | --- | --- |
 | `--mcp-http-port` | HTTP サーバーポート（HTTP モード必須） | - |
-| `--mcp-http-host` | バインドアドレス | `127.0.0.1` |
+| `--mcp-http-host` | バインドアドレス（Docker エントリポイントでは `0.0.0.0`、CLI では `127.0.0.1`） | `127.0.0.1` (CLI) |
 | `--host` | TouchDesigner WebServer ホスト | `http://127.0.0.1` |
 | `--port` | TouchDesigner WebServer ポート | `9981` |
+
+> セキュリティメモ（Docker）：コンテナ内は `0.0.0.0` で待ち受けますが、`docker-compose.yml` では `127.0.0.1:${MCP_HTTP_PORT}` にのみ公開するためデフォルトではローカル専用です。LAN/WAN に開放する場合はポートマッピングを `"0.0.0.0:6280:6280"` などに変更し、ファイアウォールやリバースプロキシ・認証を必ず併用してください。
 
 ### ヘルスチェック
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -242,7 +242,7 @@ Choose a transport configuration:
     }
     ```
 
-4. Confirm the container is healthy:
+4. Confirm the container is healthy (container binds `0.0.0.0`, Docker publishes to `127.0.0.1` by default):
 
    ```bash
    curl http://localhost:6280/health
@@ -304,9 +304,11 @@ touchdesigner-mcp-server \
 | Option | Description | Default |
 | --- | --- | --- |
 | `--mcp-http-port` | HTTP server port (required for HTTP mode) | - |
-| `--mcp-http-host` | Bind address | `127.0.0.1` |
+| `--mcp-http-host` | Bind address (`0.0.0.0` in Docker entrypoint, `127.0.0.1` in CLI) | `127.0.0.1` (CLI) |
 | `--host` | TouchDesigner WebServer host | `http://127.0.0.1` |
 | `--port` | TouchDesigner WebServer port | `9981` |
+
+> Security tip (Docker): the container binds to `0.0.0.0`, but `docker-compose.yml` publishes `127.0.0.1:${MCP_HTTP_PORT}` by default so the endpoint is loopback-only. If you intentionally expose it to your LAN/WAN, change the compose port mapping (for example `"0.0.0.0:6280:6280"`) and protect it with a firewall/reverse proxy and authentication.
 
 ### Health Check
 


### PR DESCRIPTION
This pull request updates the HTTP endpoint binding behavior for the MCP server in Docker and clarifies documentation to help users understand the default security posture and how to safely expose the service if needed. The main change restricts the published HTTP port to loopback-only by default, and the documentation now explains the implications and configuration options for both English and Japanese readers.

**Docker configuration update:**

* The `docker-compose.yml` file now maps the MCP HTTP port to `127.0.0.1` by default, making the HTTP endpoint accessible only from the local machine unless explicitly changed.

**Documentation improvements (English and Japanese):**

* Both `docs/installation.md` and `docs/installation.ja.md` now explain that the container listens on `0.0.0.0`, but the compose file publishes to `127.0.0.1`, limiting access to localhost by default. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L245-R245) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eL232-R232)
* The option table for `--mcp-http-host` is updated to clarify the default behavior for CLI vs Docker usage. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L307-R312) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eL281-R286)
* Added explicit security notes advising users to change the port mapping and use firewall/proxy/authentication if exposing the service beyond localhost. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L307-R312) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eL281-R286)