### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.1] - 2025-12-07
+
+### Changed
+
+- Adjusted the API server version to be updated and matched, as it was prompting for an update of mcp_webserver_base.tox even when using the latest NPM packages.
+
+### Technical
+
+- Aligned the versions of the Python module and OpenAPI schema (MCP_API_VERSION/info.version) to 1.4.1, and updated the compatibility check and client generation to report the new version.
+
 ## [1.4.0] - 2025-12-07
 
 ### Added

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.4.0",
+			"version": "1.4.1",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.24.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "touchdesigner-mcp"
-version = "1.3.0"
+version = "1.4.1"
 description = "TouchDesigner MCP Server - Python modules"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.8beeeaaat/touchdesigner-mcp-server",
   "description": "MCP server for TouchDesigner - Control and operate TouchDesigner projects through AI agents",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "touchdesigner-mcp-server",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -19,8 +19,8 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.0/touchdesigner-mcp.mcpb",
-      "version": "1.4.0",
+      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.1/touchdesigner-mcp.mcpb",
+      "version": "1.4.1",
       "fileSha256": "7a11f1b03ef1e009e018a9ccb0ec7e6c6c2db065a952822a7987063b1fa235b7",
       "transport": {
         "type": "stdio"

--- a/src/api/index.yml
+++ b/src/api/index.yml
@@ -1,7 +1,7 @@
 info:
   description: OpenAPI schema for generating TouchDesigner API client code
   title: TouchDesigner API
-  version: 1.3.0
+  version: 1.4.1
 
 openapi: 3.0.0
 

--- a/td/modules/utils/version.py
+++ b/td/modules/utils/version.py
@@ -2,7 +2,7 @@
 Version utilities shared across TouchDesigner MCP Python modules.
 """
 
-MCP_API_VERSION = "1.3.0"
+MCP_API_VERSION = "1.4.1"
 
 
 def get_mcp_api_version() -> str:


### PR DESCRIPTION
## [1.4.1] - 2025-12-07

### Changed

- Adjusted the API server version to be updated and matched, as it was prompting for an update of mcp_webserver_base.tox even when using the latest NPM packages.

### Technical

- Aligned the versions of the Python module and OpenAPI schema (MCP_API_VERSION/info.version) to 1.4.1, and updated the compatibility check and client generation to report the new version.