### PR TITLE
fix: update compatibility policy to allow PATCH version differences without logging

### DIFF
--- a/src/core/compatibility.ts
+++ b/src/core/compatibility.ts
@@ -79,11 +79,11 @@ const COMPATIBILITY_POLICY = {
 
 	/**
 	 * Behavior when PATCH versions differ
-	 * - 'warning': Continue with warning
+	 * - 'allow': Allow without logging
 	 */
 	[COMPATIBILITY_POLICY_TYPES.PATCH_DIFF]: {
 		compatible: true,
-		level: COMPATIBILITY_POLICY_ERROR_LEVELS.WARNING,
+		level: COMPATIBILITY_POLICY_ERROR_LEVELS.ALLOW,
 		message: generatePatchDiffMessage,
 	} as const,
 

--- a/tests/unit/compatibility.test.ts
+++ b/tests/unit/compatibility.test.ts
@@ -303,7 +303,7 @@ describe("getCompatibilityPolicy", () => {
 			COMPATIBILITY_POLICY_TYPES.PATCH_DIFF,
 		);
 		expect(policy.compatible).toBe(true);
-		expect(policy.level).toBe(COMPATIBILITY_POLICY_ERROR_LEVELS.WARNING);
+		expect(policy.level).toBe(COMPATIBILITY_POLICY_ERROR_LEVELS.ALLOW);
 		expect(policy.message).toBeDefined();
 	});
 

--- a/tests/unit/touchDesignerClient.mock.test.ts
+++ b/tests/unit/touchDesignerClient.mock.test.ts
@@ -178,10 +178,10 @@ describe("TouchDesignerClient with mocks", () => {
 			expect(result.success).toBe(true);
 		});
 
-		test("should expose compatibility notice for warnings", async () => {
+		test("should expose compatibility notice for MINOR warnings", async () => {
 			vi.mocked(touchDesignerAPI.getTdInfo).mockResolvedValue({
 				data: {
-					mcpApiVersion: "1.3.5",
+					mcpApiVersion: "1.4.0",
 					osName: "macOS",
 					osVersion: "12.6.1",
 					server: "TouchDesigner",
@@ -197,8 +197,34 @@ describe("TouchDesignerClient with mocks", () => {
 			expect(result.success).toBe(true);
 			expect(client.getAdditionalToolResultContents()).not.toBeNull();
 			expect(client.getAdditionalToolResultContents()?.[0].text).toContain(
-				"Patch Version Mismatch",
+				"Update Recommended",
 			);
+
+			vi.mocked(touchDesignerAPI.getTdInfo).mockResolvedValue(
+				compatibilityResponse,
+			);
+			await client.getTdInfo();
+			expect(client.getAdditionalToolResultContents()).toBeNull();
+		});
+
+		test("should not surface compatibility notice for PATCH differences", async () => {
+			vi.mocked(touchDesignerAPI.getTdInfo).mockResolvedValue({
+				data: {
+					mcpApiVersion: "1.3.2",
+					osName: "macOS",
+					osVersion: "12.6.1",
+					server: "TouchDesigner",
+					version: "2023.11050",
+				},
+				error: null,
+				success: true,
+			});
+
+			const client = new TouchDesignerClient({ logger: nullLogger });
+			const result = await client.getTdInfo();
+
+			expect(result.success).toBe(true);
+			expect(client.getAdditionalToolResultContents()).toBeNull();
 
 			vi.mocked(touchDesignerAPI.getTdInfo).mockResolvedValue(
 				compatibilityResponse,


### PR DESCRIPTION
This pull request updates the compatibility policy for PATCH version differences to be more permissive and adjusts related tests to match this new behavior. PATCH version mismatches will now be allowed without warnings, and the tests ensure that compatibility notices are not shown for PATCH differences but are still shown for MINOR differences.

**Compatibility policy changes:**

* Changed the PATCH version difference policy in `compatibility.ts` to use `ALLOW` instead of `WARNING`, meaning PATCH differences are now allowed without logging a warning.

**Test updates:**

* Updated `compatibility.test.ts` to expect the PATCH difference policy's level to be `ALLOW` instead of `WARNING`.
* Updated `touchDesignerClient.mock.test.ts` to clarify that compatibility notices are only shown for MINOR version warnings, and to expect the updated message "Update Recommended" instead of "Patch Version Mismatch". [[1]](diffhunk://#diff-f79f537f7e1e1c99bf764d8f0254153cb62d38a6415f1112cb780622ecf2dc0aL181-R184) [[2]](diffhunk://#diff-f79f537f7e1e1c99bf764d8f0254153cb62d38a6415f1112cb780622ecf2dc0aL200-R200)
* Added a new test to `touchDesignerClient.mock.test.ts` to verify that no compatibility notice is surfaced for PATCH version differences.