### PR TITLE
Enhance installation guide with development shortcut

### DIFF
--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -187,6 +187,8 @@ args = ["-y", "touchdesigner-mcp-server@latest", "--stdio"]
 
 ##### オプションA: [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http)
 
+<https://github.com/user-attachments/assets/4025f9cd-b19c-42f0-8274-7609650abd34>
+
 1. `TRANSPORT=http` でコンテナを起動します。
 
    ```bash
@@ -238,6 +240,16 @@ args = ["-y", "touchdesigner-mcp-server@latest", "--stdio"]
    ```bash
    curl http://localhost:6280/health
    ```
+
+##### npmコマンドでも起動可能です
+
+<https://github.com/user-attachments/assets/5447e4da-eb5a-4ebd-bbbe-3ba347d1f6fb>
+
+```bash
+# HTTP サーバーを起動
+# 127.0.0.1:6280/mcp
+npm run http
+```
 
 ##### オプションB: Stdio パススルー
 
@@ -306,14 +318,6 @@ curl http://localhost:6280/health
 | 用途 | ローカル CLI / デスクトップツール | リモートエージェント、ブラウザ統合 |
 | セッション管理 | 単一接続 | TTL 付き複数セッション |
 | ポート要件 | 不要 | 必須 |
-
-### 開発ショートカット
-
-```bash
-# MCP Inspector と同時に HTTP サーバーを起動
-# 127.0.0.1:6280/mcp
-npm run http
-```
 
 ## 動作確認
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -199,6 +199,8 @@ Choose a transport configuration:
 
 ##### Option A: Streamable HTTP ([spec](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#streamable-http))
 
+<https://github.com/user-attachments/assets/4025f9cd-b19c-42f0-8274-7609650abd34>
+
 1. Start the container with HTTP transport:
 
    ```bash
@@ -250,6 +252,16 @@ Choose a transport configuration:
    ```bash
    curl http://localhost:6280/health
    ```
+
+###### started using npm commands
+
+```bash
+# Start HTTP server
+# 127.0.0.1:6280/mcp
+npm run http
+```
+
+<https://github.com/user-attachments/assets/5447e4da-eb5a-4ebd-bbbe-3ba347d1f6fb>
 
 ##### Option B: Stdio Passthrough
 
@@ -341,14 +353,6 @@ Expected response:
 | Use Case | Local CLI / desktop tools | Remote agents, browser integrations |
 | Session Management | Single connection | Multi-session with TTL |
 | Port Required | No | Yes |
-
-### Development Shortcut
-
-```bash
-# Start HTTP server together with MCP Inspector
-# 127.0.0.1:6280/mcp
-npm run http
-```
 
 ## Verification
 


### PR DESCRIPTION
This pull request updates both the English and Japanese installation guides to improve clarity and usability for starting the HTTP server, including new instructions and visual aids. The changes streamline the documentation by moving development shortcuts into the main setup steps and adding screenshots for better guidance.

**Documentation improvements for starting the HTTP server:**

* Added a visual screenshot to illustrate the Streamable HTTP transport setup in both `docs/installation.md` and `docs/installation.ja.md`. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R202-R203) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eR190-R191)
* Introduced explicit instructions for starting the HTTP server using `npm run http` in both English and Japanese guides, making it easier for users to follow. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R256-R265) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eR244-R253)
* Included a screenshot alongside the new npm command instructions for additional clarity. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R256-R265) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eR244-R253)

**Streamlining and cleanup:**

* Removed the separate "Development Shortcut" section from both guides, integrating its content into the main setup instructions for better flow and reduced redundancy. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L345-L352) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eL310-L317)Added development shortcut for starting HTTP server and updated transport configuration section.