### PR TITLE
docs: update HTTP mode instructions in installation guides

### DIFF
--- a/docs/installation.ja.md
+++ b/docs/installation.ja.md
@@ -241,16 +241,6 @@ args = ["-y", "touchdesigner-mcp-server@latest", "--stdio"]
    curl http://localhost:6280/health
    ```
 
-##### npmコマンドでも起動可能です
-
-<https://github.com/user-attachments/assets/5447e4da-eb5a-4ebd-bbbe-3ba347d1f6fb>
-
-```bash
-# HTTP サーバーを起動
-# 127.0.0.1:6280/mcp
-npm run http
-```
-
 ##### オプションB: Stdio パススルー
 
 1. コンテナを stdio モードで起動します。
@@ -292,6 +282,26 @@ npm run http
 ## HTTP トランスポートモード
 
 TouchDesigner MCP Server は stdio だけでなく HTTP/SSE でも動作します。リモートエージェントやブラウザ統合など、必要な場合のみ本節を参照してください（Node.js CLI または Docker から起動可能）。
+
+### HTTP モードの起動
+
+#### コンテナを HTTP トランスポートで起動
+
+```bash
+TRANSPORT=http docker-compose up -d
+```
+
+<https://github.com/user-attachments/assets/4025f9cd-b19c-42f0-8274-7609650abd34>
+
+#### npm コマンドで起動
+
+```bash
+# HTTP サーバーを起動
+# 127.0.0.1:6280/mcp
+npm run http
+```
+
+<https://github.com/user-attachments/assets/5447e4da-eb5a-4ebd-bbbe-3ba347d1f6fb>
 
 ### 設定オプション
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -300,11 +300,12 @@ from the Node.js CLI or inside the Docker container.
 
 ### Starting in HTTP Mode
 
-#### Start the container with HTTP transport:
+#### Start the container with HTTP transport
 
 ```bash
 TRANSPORT=http docker-compose up -d
 ```
+
 <https://github.com/user-attachments/assets/4025f9cd-b19c-42f0-8274-7609650abd34>
 
 #### Using npm command
@@ -314,6 +315,7 @@ TRANSPORT=http docker-compose up -d
 # 127.0.0.1:6280/mcp
 npm run http
 ```
+
 <https://github.com/user-attachments/assets/5447e4da-eb5a-4ebd-bbbe-3ba347d1f6fb>
 
 ```bash


### PR DESCRIPTION
This pull request updates the installation documentation for both English (`docs/installation.md`) and Japanese (`docs/installation.ja.md`) versions to improve clarity and consistency regarding how to start the MCP server in HTTP mode. The changes reorganize and clarify instructions for starting the server using Docker and npm, and ensure that both language versions provide the same information and visual aids.

Documentation improvements:

* Reorganized the HTTP mode startup instructions in both `docs/installation.md` and `docs/installation.ja.md` to clearly separate Docker and npm startup methods, including step-by-step commands and relevant screenshots. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56R303-R320) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eR286-R305)
* Removed redundant or unclear sections about starting the server with npm to avoid confusion and ensure consistency between the English and Japanese documentation. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L256-L265) [[2]](diffhunk://#diff-61ff889cb5c8c8e10c94695078a6a23f3b5818a9ccbfafe66ed88fbe6962a08eL244-L253)