### PR TITLE
docs: add version and download badges to README files

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,5 +1,8 @@
 # TouchDesigner MCP
 
+[![Version](https://img.shields.io/npm/v/touchdesigner-mcp-server?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/touchdesigner-mcp-server)
+[![Downloads](https://img.shields.io/npm/dt/touchdesigner-mcp-server.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/touchdesigner-mcp-server)
+
 TouchDesignerのためのMCP(Model Context Protocol) サーバー実装です。AIエージェントがTouchDesignerプロジェクトを制御・操作できるようになることを目指しています。
 
 [English](README.md) / [日本語](README.ja.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # TouchDesigner MCP
 
+[![Version](https://img.shields.io/npm/v/touchdesigner-mcp-server?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/touchdesigner-mcp-server)
+[![Downloads](https://img.shields.io/npm/dt/touchdesigner-mcp-server.svg?style=flat&colorA=000000&colorB=000000)](https://www.npmjs.com/package/touchdesigner-mcp-server)
+
 This is an implementation of an MCP (Model Context Protocol) server for TouchDesigner. Its goal is to enable AI agents to control and operate TouchDesigner projects.
 
 [English](README.md) / [日本語](README.ja.md)


### PR DESCRIPTION
This pull request updates the project documentation by adding status badges to both the English and Japanese README files. These badges display the current npm package version and total downloads, making it easier for users to quickly see the package status.

Documentation improvements:

* Added npm version and download badges to the top of `README.md` to display the current package version and total downloads.
* Added npm version and download badges to the top of `README.ja.md` for consistency across language versions.