### PR TITLE
v1.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.6] - 2026-04-01
+
+### Security
+
+- Pinned `axios` to exact version `1.13.6` (removed caret range `^1.13.6`) in both `dependencies` and `overrides` to mitigate the [axios supply chain attack](https://socket.dev/npm/package/axios/overview/1.14.1). The malicious `axios@1.14.1` was published to npm in late March 2026 and has since been removed. Users who ran `npx touchdesigner-mcp-server` during the compromise window (late March 2026) should check for the presence of `plain-crypto-js` in their `node_modules` and reinstall if found.
+
+<https://github.com/8beeeaaat/touchdesigner-mcp/issues/167> @annsts thx!
+
+#### For users who may have been affected
+
+If you ran npx touchdesigner-mcp-server during late March 2026, please refer to the remediation guidance in the references below. Key steps include checking for the presence of plain-crypto-js in your node_modules, removing and reinstalling if found, and rotating any secrets or credentials that may have been exposed.
+
+##### References
+
+[Axios Supply Chain Attack Pushes Cross-Platform RAT via Compromised npm Account — The Hacker News](https://thehackernews.com/2026/03/axios-supply-chain-attack-pushes-cross.html)
+
+[axios Compromised on npm — StepSecurity](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan)
+
+[North Korea-Nexus Threat Actor Compromises Axios NPM Package — Google Cloud Blog](https://cloud.google.com/blog/topics/threat-intelligence/north-korea-threat-actor-targets-axios-npm-package?hl=en)
+
 ## [1.4.5] - 2026-03-06
 
 ### Added

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@types/axios": "^0.14.4",
 				"@types/ws": "^8.18.1",
 				"@types/yargs": "^17.0.35",
-				"axios": "^1.13.6",
+				"axios": "1.13.6",
 				"express": "^5.2.1",
 				"mustache": "^4.2.0",
 				"semver": "^7.7.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.5",
+	"version": "1.4.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.4.5",
+			"version": "1.4.6",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "^1.27.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.5",
+	"version": "1.4.6",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"@types/axios": "^0.14.4",
 		"@types/ws": "^8.18.1",
 		"@types/yargs": "^17.0.35",
-		"axios": "^1.13.6",
+		"axios": "1.13.6",
 		"express": "^5.2.1",
 		"mustache": "^4.2.0",
 		"semver": "^7.7.4",
@@ -104,6 +104,6 @@
 		]
 	},
 	"overrides": {
-		"axios": "^1.13.6"
+		"axios": "1.13.6"
 	}
 }

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.8beeeaaat/touchdesigner-mcp-server",
   "description": "MCP server for TouchDesigner - Control and operate TouchDesigner projects through AI agents",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "repository": {
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "touchdesigner-mcp-server",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -19,9 +19,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.5/touchdesigner-mcp.mcpb",
-      "version": "1.4.5",
-      "fileSha256": "302cbcc82625058828628e89eb87af92e80580eed1d775028cccc30687b6865d",
+      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.6/touchdesigner-mcp.mcpb",
+      "version": "1.4.6",
+      "fileSha256": "0d609b5b366a35af1ae8e481931943cd3706fbf3205f7d431b6926ece646480c",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
- close https://github.com/8beeeaaat/touchdesigner-mcp/issues/167 @annsts thx!

## [1.4.6] - 2026-04-01

### Security

- Pinned `axios` to exact version `1.13.6` (removed caret range `^1.13.6`) in both `dependencies` and `overrides` to mitigate the [axios supply chain attack](https://socket.dev/npm/package/axios/overview/1.14.1). The malicious `axios@1.14.1` was published to npm in late March 2026 and has since been removed. Users who ran `npx touchdesigner-mcp-server` during the compromise window (late March 2026) should check for the presence of `plain-crypto-js` in their `node_modules` and reinstall if found.

#### For users who may have been affected

If you ran npx touchdesigner-mcp-server during late March 2026, please refer to the remediation guidance in the references below. Key steps include checking for the presence of plain-crypto-js in your node_modules, removing and reinstalling if found, and rotating any secrets or credentials that may have been exposed.

##### References

[Axios Supply Chain Attack Pushes Cross-Platform RAT via Compromised npm Account — The Hacker News](https://thehackernews.com/2026/03/axios-supply-chain-attack-pushes-cross.html)

[axios Compromised on npm — StepSecurity](https://www.stepsecurity.io/blog/axios-compromised-on-npm-malicious-versions-drop-remote-access-trojan)

[North Korea-Nexus Threat Actor Compromises Axios NPM Package — Google Cloud Blog](https://cloud.google.com/blog/topics/threat-intelligence/north-korea-threat-actor-targets-axios-npm-package?hl=en)