### PR TITLE
v1.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.10] - 2026-06-18
+
+### Fixed
+
+- Enabled TypeScript declaration emit (`declaration: true` in `tsconfig.json`) so the published package actually ships the `.d.ts` files it already advertises through `types: dist/index.d.ts` and the typed `exports` map. Previously `build:dist` emitted only JavaScript, so TypeScript consumers installing `touchdesigner-mcp-server` got `Could not find a declaration file` errors despite the package metadata promising declarations ([#176](https://github.com/8beeeaaat/touchdesigner-mcp/pull/176)).
+
+### Changed
+
+- Released version `1.4.10` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB checksum so npm and MCPB installations resolve the same release. The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) stays at `1.4.3` since this release contains no server/API contract changes.
+
 ## [1.4.9] - 2026-06-13
 
 ### Changed

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.9",
+	"version": "1.4.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.4.9",
+			"version": "1.4.10",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.9",
+	"version": "1.4.10",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.8beeeaaat/touchdesigner-mcp-server",
   "description": "MCP server for TouchDesigner - Control and operate TouchDesigner projects through AI agents",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "repository": {
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "touchdesigner-mcp-server",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -19,9 +19,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.9/touchdesigner-mcp.mcpb",
-      "version": "1.4.9",
-      "fileSha256": "ae170cc831f095715322e97b29efe8a9f6893557ae595c412e5f5132630fd6c0",
+      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.10/touchdesigner-mcp.mcpb",
+      "version": "1.4.10",
+      "fileSha256": "b90d06e3c8f2d3812b8d357c2e5bebedf1739154697cf7704c5085b2e5b78a6c",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Release `1.4.10`. Builds on the merged PR #176 to ship the fix in a published release.

### Fixed
- **Publish TypeScript declarations** (#176): enabled `declaration: true` in `tsconfig.json` so `build:dist` emits the `.d.ts` files the package already advertises via `types: dist/index.d.ts` and the typed `exports` map. Before this, the published package shipped JS only, so TypeScript consumers hit `Could not find a declaration file` errors. `declarationMap` was intentionally **not** enabled — `src/` is not published (`files: ["dist/**/*"]`), so the maps would be dead weight.

### Release Chores
- Bumped package version to `1.4.10` across `package.json`, `mcpb/manifest.json`, and `server.json`.
- MCP API version stays at `1.4.3` (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) — no server/API contract change, so no TD `.tox` re-import required.
- Added CHANGELOG entry for `1.4.10`.

## Verification

- `npm run build` — codegen → `tsc` (declaration emit) → mcpb pack succeed. Confirmed `dist/index.d.ts` and `dist/cli.d.ts` are emitted at the paths the package metadata references; 44 `.d.ts` files total, 0 `.d.ts.map` files.
- `npm run lint` — Biome / tsc / Ruff / Prettier all pass.
- `npm run test:unit` — 242 tests pass (17 files).
- No codegen diffs in `src/gen` or `td/modules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)