### PR TITLE
v1.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.12] - 2026-07-02
+
+### Fixed
+
+- Fixed the TouchDesigner WebServer component failing to initialize with `ModuleNotFoundError: No module named 'mcp.controllers'` (and the same failure for `utils.error_handling`) when TouchDesigner's Python already contains same-named `mcp` / `utils` packages (e.g. the Anthropic MCP SDK, PyPI name `mcp`). Corrected `import_modules` so the project `modules/` paths take priority in `sys.path` and any cached `mcp*` entries are evicted from `sys.modules`, added the missing `__init__.py` files so `modules/mcp/` and `modules/utils/` are regular packages instead of shadowable namespace packages, and re-synced the `import_modules` DAT embedded in `mcp_webserver_base.tox` so the released `.tox` runs the fixed logic ([#173](https://github.com/8beeeaaat/touchdesigner-mcp/issues/173), [#181](https://github.com/8beeeaaat/touchdesigner-mcp/pull/181)).
+
+### Changed
+
+- Released version `1.4.12` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB download URL and checksum so npm and MCPB installations resolve the same release. The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) stays at `1.4.3` since this release contains no server/API contract changes. No dependency updates are included.
+
 ## [1.4.11] - 2026-06-27
 
 ### Changed

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.11",
+	"version": "1.4.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.4.11",
+			"version": "1.4.12",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.11",
+	"version": "1.4.12",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.8beeeaaat/touchdesigner-mcp-server",
   "description": "MCP server for TouchDesigner - Control and operate TouchDesigner projects through AI agents",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "repository": {
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "touchdesigner-mcp-server",
-      "version": "1.4.11",
+      "version": "1.4.12",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -19,9 +19,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.11/touchdesigner-mcp.mcpb",
-      "version": "1.4.11",
-      "fileSha256": "956884f7e83a493739bcb2c7279677e21a2cbc3415c76a3ad6fdf2e7265a25d9",
+      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.12/touchdesigner-mcp.mcpb",
+      "version": "1.4.12",
+      "fileSha256": "355eb9b74a0c34ab8b8725035866040c8c431eb052c4cb473af7d4e3b410cb6a",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

Bug-fix release delivering the fix from #181 (issue #173) to users. **No dependency updates**, **no API contract changes**.

## [1.4.12] - 2026-07-02

### Fixed

- Fixed the TouchDesigner WebServer component failing to initialize with `ModuleNotFoundError: No module named 'mcp.controllers'` (and the same failure for `utils.error_handling`) when TouchDesigner's Python already contains same-named `mcp` / `utils` packages (e.g. the Anthropic MCP SDK, PyPI name `mcp`). Corrected `import_modules` so the project `modules/` paths take priority in `sys.path` and any cached `mcp*` entries are evicted from `sys.modules`, added the missing `__init__.py` files so `modules/mcp/` and `modules/utils/` are regular packages instead of shadowable namespace packages, and re-synced the `import_modules` DAT embedded in `mcp_webserver_base.tox` so the released `.tox` runs the fixed logic ([#173](https://github.com/8beeeaaat/touchdesigner-mcp/issues/173), [#181](https://github.com/8beeeaaat/touchdesigner-mcp/pull/181)).

### Changed

- Released version `1.4.12` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB download URL and checksum so npm and MCPB installations resolve the same release. The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) stays at `1.4.3` since this release contains no server/API contract changes. No dependency updates are included.

### Fixed (#173 / #181)
- The TouchDesigner WebServer component failed to initialize with `ModuleNotFoundError: No module named 'mcp.controllers'` (and the same for `utils.error_handling`) when TouchDesigner's Python already contains same-named `mcp` / `utils` packages (e.g. the Anthropic MCP SDK, PyPI name `mcp`).
- `import_modules` now inserts the project `modules/` paths at the **front** of `sys.path` and evicts cached `mcp*` entries from `sys.modules`, so local packages win.
- Added the missing `__init__.py` for `modules/mcp/` and `modules/utils/` so they are regular packages instead of shadowable namespace packages.
- Re-synced the `import_modules` DAT embedded in `mcp_webserver_base.tox` so the released `.tox` runs the fixed logic. (The `.tox` / `td/modules` code itself was finalized in #181 and is not modified by this release PR.)

### Release chores
- Bumped package version `1.4.11 → 1.4.12` across `package.json`, `package-lock.json` (version field only — no dependency changes), `mcpb/manifest.json`, and `server.json` (version, MCPB download URL, and checksum).
- **API version stays at `1.4.3`** — this release contains no server/API (endpoint / request / response schema) contract changes, so `src/api/index.yml`, `td/modules/utils/version.py`, and `pyproject.toml` remain at `1.4.3` (consistent with 1.4.9–1.4.11). No TouchDesigner `.tox` re-import is required for compatibility.
- **No dependency updates**: `npm audit`, `npm update`, and `npm audit fix` were not run; `package-lock.json` changes are limited to the root/package version field.

> Note: per the known MCPB checksum non-determinism, `server.json.fileSha256` matches the locally built `.mcpb` at commit time and may differ from the CI-attached release asset.

## Verification

| Check | Result |
| --- | --- |
| `npm run build` (codegen → tsc → mcpb) | pass — no `td/modules` / `src/gen` diffs |
| `npm run lint` (Biome / tsc / Ruff / Prettier) | pass |
| `npm run test:unit` | pass — 242 tests, 17 files |

MCP protocol / live TouchDesigner verification is tracked separately by the release manager.