### PR TITLE
fix: show captured stdout/stderr in execute_python_script responses (#183)

### DIFF
--- a/src/api/paths/api/td/server/exec.yml
+++ b/src/api/paths/api/td/server/exec.yml
@@ -45,6 +45,12 @@ post:
                     properties:
                       value:
                         description: Return value of the executed script, can be any serializable value
+                  stdout:
+                    type: string
+                    description: Captured standard output (e.g. print statements) emitted while the script ran
+                  stderr:
+                    type: string
+                    description: Captured standard error output emitted while the script ran
               error:
                 nullable: true
                 type: string

--- a/src/features/tools/presenter/scriptResultFormatter.ts
+++ b/src/features/tools/presenter/scriptResultFormatter.ts
@@ -23,7 +23,8 @@ export interface ScriptResultData {
 	success?: boolean;
 	data?: {
 		result?: unknown;
-		output?: string;
+		stdout?: string;
+		stderr?: string;
 		error?: string;
 	};
 	[key: string]: unknown;
@@ -36,6 +37,8 @@ interface ScriptSummaryContext {
 	hasOutput: boolean;
 	outputType: string;
 	outputPreview?: string;
+	hasStderr: boolean;
+	stderrPreview?: string;
 }
 
 /**
@@ -54,7 +57,8 @@ export function formatScriptResult(
 
 	const success = data.success ?? true;
 	const result = data.data?.result;
-	const output = data.data?.output;
+	const stdout = data.data?.stdout;
+	const stderr = data.data?.stderr;
 	const error = data.data?.error;
 
 	// Error case - always show full details
@@ -72,10 +76,10 @@ export function formatScriptResult(
 	switch (opts.detailLevel) {
 		case "minimal":
 			formattedText = formatMinimal(result);
-			context = buildScriptContext(scriptSnippet, result, output);
+			context = buildScriptContext(scriptSnippet, result, stdout, stderr);
 			break;
 		case "summary": {
-			const summary = formatSummary(result, output, scriptSnippet);
+			const summary = formatSummary(result, stdout, stderr, scriptSnippet);
 			formattedText = summary.text;
 			context = summary.context;
 			break;
@@ -134,7 +138,8 @@ function formatMinimal(result: unknown): string {
  */
 function formatSummary(
 	result: unknown,
-	output?: string,
+	stdout?: string,
+	stderr?: string,
 	scriptSnippet?: string,
 ): { text: string; context: ScriptSummaryContext } {
 	let formatted = "✓ Script executed successfully\n\n";
@@ -147,20 +152,24 @@ function formatSummary(
 		resultPreview = formatResultValue(result, 500);
 		formatted += `Result: ${resultPreview}\n`;
 	}
-	let outputPreview: string | undefined;
-	if (output?.trim()) {
-		outputPreview =
-			output.length > 200 ? `${output.substring(0, 200)}...` : output;
+	const outputPreview = truncateOutput(stdout);
+	if (outputPreview) {
 		formatted += `\nOutput:\n${outputPreview}`;
+	}
+	const stderrPreview = truncateOutput(stderr);
+	if (stderrPreview) {
+		formatted += `\nStderr:\n${stderrPreview}`;
 	}
 	return {
 		context: {
 			hasOutput: Boolean(outputPreview),
+			hasStderr: Boolean(stderrPreview),
 			outputPreview,
-			outputType: getValueType(output),
+			outputType: getValueType(stdout),
 			resultPreview,
 			resultType: getValueType(result),
 			snippet,
+			stderrPreview,
 		},
 		text: formatted,
 	};
@@ -169,16 +178,29 @@ function formatSummary(
 function buildScriptContext(
 	scriptSnippet: string | undefined,
 	result: unknown,
-	output?: string,
+	stdout?: string,
+	stderr?: string,
 ): ScriptSummaryContext {
 	return {
-		hasOutput: Boolean(output?.trim()),
-		outputPreview: output,
-		outputType: getValueType(output),
+		hasOutput: Boolean(stdout?.trim()),
+		hasStderr: Boolean(stderr?.trim()),
+		outputPreview: stdout,
+		outputType: getValueType(stdout),
 		resultPreview: formatResultValue(result ?? "", 200),
 		resultType: getValueType(result),
 		snippet: scriptSnippet ? truncateScript(scriptSnippet) : "",
+		stderrPreview: stderr,
 	};
+}
+
+/**
+ * Truncate captured stdout/stderr for display
+ */
+function truncateOutput(output?: string): string | undefined {
+	if (!output?.trim()) {
+		return undefined;
+	}
+	return output.length > 200 ? `${output.substring(0, 200)}...` : output;
 }
 
 /**

--- a/src/features/tools/presenter/templates/markdown/scriptSummary.md
+++ b/src/features/tools/presenter/templates/markdown/scriptSummary.md
@@ -9,7 +9,16 @@
 ```
 
 {{#outputPreview}}
+Output:
+
 ```text
 {{{outputPreview}}}
 ```
 {{/outputPreview}}
+{{#stderrPreview}}
+Stderr:
+
+```text
+{{{stderrPreview}}}
+```
+{{/stderrPreview}}

--- a/tests/unit/presenters/scriptResultFormatter.test.ts
+++ b/tests/unit/presenters/scriptResultFormatter.test.ts
@@ -72,8 +72,8 @@ describe("scriptResultFormatter", () => {
 		it("should format successful execution with result and output in summary mode", () => {
 			const data: ScriptResultData = {
 				data: {
-					output: "Debug message",
 					result: { value: 123 },
+					stdout: "Debug message",
 				},
 				success: true,
 			};
@@ -89,6 +89,42 @@ describe("scriptResultFormatter", () => {
 			expect(result).toContain("Return type: object");
 			expect(result).toContain('"value": 123');
 			expect(result).toContain("Debug message");
+		});
+
+		it("should show captured stdout from print statements in summary mode", () => {
+			const data: ScriptResultData = {
+				data: {
+					result: "done",
+					stdout: "HELLO\n",
+				},
+				success: true,
+			};
+
+			const result = formatScriptResult(data, "print('HELLO')", {
+				detailLevel: "summary",
+			});
+
+			expect(result).toContain("Output:");
+			expect(result).toContain("HELLO");
+		});
+
+		it("should show captured stderr in summary mode", () => {
+			const data: ScriptResultData = {
+				data: {
+					result: "done",
+					stderr: "warning: something happened\n",
+					stdout: "",
+				},
+				success: true,
+			};
+
+			const result = formatScriptResult(data, undefined, {
+				detailLevel: "summary",
+			});
+
+			expect(result).toContain("Stderr:");
+			expect(result).toContain("warning: something happened");
+			expect(result).not.toContain("Output:");
 		});
 
 		it("should truncate long script snippets in summary mode", () => {
@@ -111,8 +147,8 @@ describe("scriptResultFormatter", () => {
 		it("should truncate long output in summary mode", () => {
 			const data: ScriptResultData = {
 				data: {
-					output: "x".repeat(250),
 					result: "ok",
+					stdout: "x".repeat(250),
 				},
 				success: true,
 			};
@@ -162,8 +198,8 @@ describe("scriptResultFormatter", () => {
 		it("should return full JSON in detailed mode", () => {
 			const data: ScriptResultData = {
 				data: {
-					output: "Some output",
 					result: { complex: "data", nested: { value: 123 } },
+					stdout: "Some output",
 				},
 				success: true,
 			};
@@ -176,7 +212,7 @@ describe("scriptResultFormatter", () => {
 			expect(result).toContain('"success": true');
 			expect(result).toContain('"complex": "data"');
 			expect(result).toContain('"nested"');
-			expect(result).toContain('"output": "Some output"');
+			expect(result).toContain('"stdout": "Some output"');
 		});
 
 		it("should handle undefined data", () => {
@@ -188,8 +224,8 @@ describe("scriptResultFormatter", () => {
 		it("should handle empty output string", () => {
 			const data: ScriptResultData = {
 				data: {
-					output: "",
 					result: "ok",
+					stdout: "",
 				},
 				success: true,
 			};
@@ -204,8 +240,8 @@ describe("scriptResultFormatter", () => {
 		it("should handle whitespace-only output", () => {
 			const data: ScriptResultData = {
 				data: {
-					output: "   \n\t  ",
 					result: "ok",
+					stdout: "   \n\t  ",
 				},
 				success: true,
 			};


### PR DESCRIPTION
## Summary

Fixes #183. The TD-side `api_service` returns captured output under `stdout` / `stderr`, but the formatter read a non-existent `output` key, so `print()` output was silently dropped in summary/minimal responses (it only surfaced via the raw dump in detailed mode).

- Document `stdout` / `stderr` in the OpenAPI schema (exec endpoint)
- Read `stdout` / `stderr` in `scriptResultFormatter` and render labeled `Output:` / `Stderr:` sections in the markdown template
- Update unit tests to the real response keys; add stdout/stderr display cases

## Verification

- `npm run test:unit` → 244 passed / `biome check`, `tsc --noEmit` clean
- E2E: built this branch and ran `node dist/cli.js --stdio` against TouchDesigner 2025.32820 (macOS 15 arm64), called `execute_python_script` with `print('E2E_STDOUT_CHECK')` + `sys.stderr.write('E2E_STDERR_CHECK')` → both now appear in the default (summary) response:

```
Output:

E2E_STDOUT_CHECK

Stderr:

E2E_STDERR_CHECK
```

- Note: `test:integration` has one failure in my environment ("Auto-created nodes are placed on a non-overlapping grid") that reproduces identically on clean `main` — my installed td-side package is v1.4.12 and predates the auto-layout feature. Unrelated to this change.

---

#183 の修正です。フォーマッタが存在しない `output` キーを参照していたのを、TD側が実際に返す `stdout` / `stderr` に合わせ、OpenAPIスキーマにも明記しました。テンプレートには `Output:` / `Stderr:` のラベル付きセクションを追加しています。
