### PR TITLE
fix: include Python traceback in exec_python_script error responses (#184)

### DIFF
--- a/td/modules/mcp/services/api_service.py
+++ b/td/modules/mcp/services/api_service.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 import io
 import pydoc
+import traceback
 from typing import Any, Optional, Protocol
 
 from mcp.services.node_layout import first_free_cell
@@ -498,7 +499,9 @@ class TouchDesignerApiService(IApiService):
 					}
 				)
 			except Exception as exec_error:
-				raise Exception(f"Script execution failed: {str(exec_error)}")
+				raise Exception(
+					f"Script execution failed: {exec_error}\n{traceback.format_exc()}"
+				) from exec_error
 
 	def update_node(self, node_path: str, properties: dict[str, Any]) -> Result:
 		"""Update properties of the node at the specified path"""


### PR DESCRIPTION
## Summary

Fixes #184. Script failures previously surfaced only `str(exception)`; with multi-line scripts you couldn't tell which line failed or how far execution got (side effects up to the failing line are already applied). Append `traceback.format_exc()` to the raised error message and chain the original exception with `from`.

## Verification

- `ruff check td/` / `ruff format --check td/` clean
- E2E on TouchDesigner 2025.32820 (macOS 15 arm64): a 5-line script raising in a nested function now returns

```
Script execution failed: boom at line 3
Traceback (most recent call last):
  File ".../api_service.py", line ..., in exec_python_script
  File "<string>", line 5, in <module>
  File "<string>", line 3, in inner
ValueError: boom at line 3
```

(previously just `Script execution failed: boom at line 3`)

---

#184 の修正です。`traceback.format_exc()` をエラーメッセージに含め、複数行スクリプトのどの行で失敗したか（＝どこまで副作用が反映されたか）を特定できるようにしました。
