### PR TITLE
fix: expose TouchDesigner globals in exec_python_script namespace (#185)

### DIFF
--- a/td/modules/mcp/services/api_service.py
+++ b/td/modules/mcp/services/api_service.py
@@ -8,6 +8,7 @@ import importlib
 import inspect
 import io
 import pydoc
+import sys
 from typing import Any, Optional, Protocol
 
 from mcp.services.node_layout import first_free_cell
@@ -418,7 +419,18 @@ class TouchDesignerApiService(IApiService):
 			"td": td,
 			"result": no_result_sentinel,
 		}
+		# Mirror the Textport/DAT execution environment: TouchDesigner keeps
+		# all of its globals (absTime, OP type names such as noiseTOP, ParMode,
+		# tdu, ui, ...) in the __main__ module namespace. Merging them makes
+		# scripts behave the same as Python written inside a DAT or the
+		# Textport, so code can be copy-pasted between both contexts.
+		td_globals = {
+			name: value
+			for name, value in vars(sys.modules["__main__"]).items()
+			if not name.startswith("_")
+		}
 		namespace = dict(globals())
+		namespace.update(td_globals)
 		namespace.update(local_vars)
 
 		stdout_capture = io.StringIO()


### PR DESCRIPTION
## Summary

Fixes #185. Scripts executed via MCP only saw `op/ops/me/parent/project/td`, so DAT-context Python failed via MCP (`absTime`, OP type names like `noiseTOP`, `ParMode`, `tdu`, ... were NameErrors) and code couldn't be copy-pasted between DAT callbacks and MCP scripts.

While implementing this I found that `vars(td)` (810 names) does **not** contain `ParMode` and misses ~70 OP type aliases, so the fix proposed in the issue was insufficient. TouchDesigner injects its full global set (928 names) into the **`__main__` module namespace** — the same names the Textport and DAT contexts resolve. This PR merges `vars(sys.modules["__main__"])` (minus underscore names) into the exec namespace; the existing `local_vars` bindings are applied afterwards and keep precedence. Result: scripts behave like the Textport.

## Verification

- `ruff check td/` / `ruff format --check td/` clean
- E2E on TouchDesigner 2025.32820 (macOS 15 arm64): the following runs unmodified via `execute_python_script` (every name here was a NameError before):

```python
t = absTime.seconds
n = op('/project1/blob_scanner').create(noiseTOP, 'tmp_e2e_noise')
n.par.period.expr = 'absTime.seconds % 10 + 1'
n.par.period.mode = ParMode.EXPRESSION
u = tdu.clamp(5, 0, 3)
```

---

#185 の修正です。調査の結果 `ParMode` は `vars(td)` に無く（OP型エイリアス約70件も不足）、TDの全グローバルは `__main__`（Textport名前空間）に注入されていることが分かったため、issue の当初案より正確な「`__main__` をマージして Textport と同じ挙動にする」実装にしました。既存の `local_vars` は後から適用され優先されます。
