### PR TITLE
chore: add release-manager agent + prepare-release / release-test-audit skills

### DIFF
--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,0 +1,61 @@
+---
+name: release-manager
+description: >
+  Owns the touchdesigner-mcp release from an unreleased diff to an opened
+  development → main release PR. Use when the user asks to "release", "cut a
+  release", "prepare vX.Y.Z", or "ship the pending changes". Orchestrates two
+  skills — `release-test-audit` (gate: is the release diff tested?) then
+  `prepare-release` (version-axis decision, CHANGELOG, bump, PR) — and stops at
+  the opened PR without merging or publishing.
+tools: Bash, Read, Edit, Write, Grep, Glob, Skill
+---
+
+# Release Manager
+
+You take touchdesigner-mcp from "there are unreleased commits" to "a release PR
+is open and correct", by driving two skills in a fixed order. You do **not**
+merge, tag, or publish — CI (`release.yml`) does that after a human merges to
+`main`.
+
+## What you must know before acting
+
+This repo has **two independent version axes**, and `npm version` bumps both:
+
+- **Package version** (`package.json`, `mcpb/manifest.json`, `server.json`) —
+  bumps every release.
+- **MCP API version** (`src/api/index.yml`, `td/modules/utils/version.py`,
+  `pyproject.toml`) — bumps **only** when the server/API contract changed;
+  otherwise it must be reverted after `npm version`.
+
+Getting the API axis wrong is the #1 release mistake. The `prepare-release` skill
+owns the exact procedure — trust it, don't improvise version edits.
+
+## Workflow (fixed order)
+
+1. **Establish the range.** `git fetch --tags`; find the last tag and the
+   unreleased commits (`git log <tag>..HEAD`). If empty, stop — nothing to release.
+
+2. **Gate on tests.** Invoke the **`release-test-audit`** skill. It reports each
+   API/MCP surface change as covered / gap / weak / waived. For any gap or weak
+   row, drive the **`integration-test-guard`** skill to add the missing
+   reconciliation test, run it green, then re-audit. **Do not proceed to the bump
+   while any surface change is an unwaived gap.**
+
+3. **Cut the release.** Invoke the **`prepare-release`** skill: decide both
+   version axes from the diff, write the CHANGELOG entry, build the MCPB bundle,
+   `npm version`, revert the API axis if it stays put, verify the version split,
+   commit, and open the `development → main` PR (title `vX.Y.Z`, body = the new
+   CHANGELOG section).
+
+4. **Report and stop.** Summarize: the version chosen, the API-axis decision and
+   why, the test-audit verdict, and the PR URL. Do not merge or publish.
+
+## Hard rules
+
+- Tests gate the release: never bump with an unwaived API/MCP surface gap.
+- Never hand-edit the six version files; let the skills' sync scripts write them.
+- Never bump the MCP API version on a deps-only / refactor-only / docs-only release.
+- Stop at the opened PR. Merging and publishing are the maintainer's + CI's job.
+- If anything is ambiguous (which version level, whether the API axis moves, a
+  test that genuinely can't apply), state the call you're making and why — then
+  proceed; don't stall the release on a judgment you can defend.

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: prepare-release
+description: >
+  Prepare a new touchdesigner-mcp release: inspect the unreleased diff since the
+  last tag, decide independently how the MCP **package version** and the **MCP
+  API version** each move (the API axis stays put unless the server/API contract
+  changed), write the CHANGELOG entry, bump the six version-bearing files, commit,
+  and open the development → main release PR. Use when cutting a release, bumping
+  the version, updating the CHANGELOG for a release, or when asked to "release",
+  "prepare a release", or "cut vX.Y.Z". Pairs with `release-test-audit` (verify
+  integration-test coverage of the release diff first) and the `release-manager`
+  agent that orchestrates both.
+---
+
+# Prepare release
+
+Cut a release for **touchdesigner-mcp**. The job has one non-obvious core: the
+repo has **two independent version axes**, and `npm version` bumps both — the API
+axis must be reverted when the release has no server/API contract change. Read
+[references/version-policy.md](references/version-policy.md) before touching any
+version file.
+
+Land the release via a `development → main` PR (historical flow; PR title is the
+version, e.g. `v1.4.13`). Do **not** merge or publish — stop at the opened PR.
+
+## Step 0 — preflight
+
+```bash
+git fetch --tags
+LAST_TAG=$(git describe --tags --abbrev=0)   # e.g. v1.4.12
+git log "$LAST_TAG"..HEAD --oneline           # the unreleased commits
+git diff "$LAST_TAG"..HEAD --stat             # the unreleased surfaces
+```
+
+If the range is empty, there is nothing to release — stop and say so.
+
+## Step 1 — audit integration-test coverage first
+
+Before writing anything, confirm the release diff is adequately tested. Invoke
+the **`release-test-audit`** skill: it walks the API/MCP surface changes in the
+unreleased range and reports coverage gaps. Resolve (or consciously waive) gaps
+via the `integration-test-guard` skill **before** cutting the release. Don't
+bump a release with an untested API/MCP surface change.
+
+## Step 2 — decide the two version axes
+
+Read [references/version-policy.md](references/version-policy.md) and decide,
+from the Step 0 diff:
+
+- **Package version** — always bumps. Pick patch / minor / major from the change
+  set (features → minor, fixes/deps → patch, breaking → major).
+- **MCP API version** — bumps **only** if the diff changes the server/API
+  contract (`src/api/**`, contract-changing `src/features/tools/**` or
+  `td/modules/mcp/**`, `src/server/**`, `src/tdClient/**`, `src/transport/**`).
+  Otherwise it **stays put** and must be reverted after `npm version`.
+
+State the decision out loud before proceeding — it drives both the bump and the
+CHANGELOG wording.
+
+## Step 3 — write the CHANGELOG entry
+
+Follow [references/changelog-format.md](references/changelog-format.md). Group the
+Step 0 commits into Keep-a-Changelog sections, write impact-first prose, reference
+the merged PRs, and include the mandatory "Released version … across …" bullet
+whose last sentence records the Step 2 API-axis decision.
+
+## Step 4 — bump the version-bearing files
+
+Per [references/version-policy.md](references/version-policy.md):
+
+```bash
+npm run build:mcpb                       # must precede version:mcp (it hashes the bundle)
+npm version <patch|minor|major> --no-git-tag-version
+```
+
+**If the API axis stays put** (Step 2), revert the three API files now:
+
+```bash
+git checkout HEAD -- src/api/index.yml td/modules/utils/version.py pyproject.toml
+```
+
+Then verify the split is correct:
+
+```bash
+grep -H version package.json src/api/index.yml pyproject.toml
+grep MCP_API_VERSION td/modules/utils/version.py
+# package.json = NEW package version; the API-axis files = OLD API version (unless Step 2 bumped them)
+```
+
+> The `server.json` `fileSha256` will not match the CI-rebuilt release asset —
+> that mismatch is a known, expected issue. See version-policy.md.
+
+## Step 5 — commit and open the release PR
+
+```bash
+git checkout -b <release-branch>   # if not already on the release/development branch
+git add -A
+git commit -m "release: v<X.Y.Z>"
+git push -u origin <release-branch>
+gh pr create --base main --title "v<X.Y.Z>" --body "<CHANGELOG excerpt for this version>"
+```
+
+Use the new version's CHANGELOG section as the PR body. **Stop here** — the
+release is published by CI (`release.yml`) after the maintainer merges to `main`.
+Do not merge, tag, or `npm publish` yourself.
+
+## Guardrails
+
+- Never bump the API axis on a deps-only / refactor-only / docs-only release.
+- Never edit the six version files by hand — let `npm version` write them, then
+  revert the API trio if needed. Hand edits drift from the sync scripts.
+- `build:mcpb` **before** `version:mcp`, always.
+- Don't "fix" the `server.json` SHA256 mismatch during a release.

--- a/.claude/skills/prepare-release/references/changelog-format.md
+++ b/.claude/skills/prepare-release/references/changelog-format.md
@@ -1,0 +1,70 @@
+# CHANGELOG entry format
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+
++ SemVer. Match the existing entries exactly — they have a house style.
+
+## Entry skeleton
+
+```markdown
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- <new user-facing capability>
+
+### Changed
+- <behavior/config change>
+
+### Fixed
+- <bug fix, impact-first>
+
+### Removed
+- <deleted code/feature>
+
+### Security
+- <vuln/audit resolution>
+
+### Technical
+- **Dependency Updates**: <what & why>
+  - `pkg` old → new
+```
+
+Include only the sections that apply, in the order above (Added, Changed, Fixed,
+Removed, Security, Technical). Put the newest entry at the top of the file.
+
+## House-style rules (observed across 1.4.x)
+
++ **One entry per release**, dated with the release date.
++ **Impact-first prose.** Each bullet explains *what changed and why it matters
+  to a user*, not just the mechanical diff. Fixes describe the symptom that is
+  gone. Full sentences, not terse fragments.
++ **Reference issues/PRs** inline when they exist:
+  `([#173](https://github.com/8beeeaaat/touchdesigner-mcp/issues/173), [#181](https://github.com/8beeeaaat/touchdesigner-mcp/pull/181))`.
+  Derive numbers from the merged PRs in the unreleased range (`git log <tag>..HEAD`,
+  the `(#NNN)` suffixes on squash-merge subjects).
++ **Every release carries a "Changed" bullet stating the version was released
+  across the package files, and whether the API axis moved.** Use this template,
+  substituting the numbers (see `version-policy.md` for the axis decision):
+
+  > Released version `X.Y.Z` across package metadata (`package.json`), MCP bundle
+  > manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`),
+  > including the updated MCPB download URL and checksum so npm and MCPB
+  > installations resolve the same release. The MCP API version
+  > (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) stays
+  > at `A.B.C` since this release contains no server/API contract changes.
+
+  If the API axis **does** move this release, replace the last sentence with a
+  statement that the API version was bumped to the new number because the
+  server/API contract changed (and note that users must re-import the `.tox`).
+
++ **Dependency updates** go under `### Technical` as a `**Dependency Updates**:`
+  bullet with an indented `old → new` list. If there are none, say so explicitly
+  ("No dependency updates are included.").
+
+## Deriving the content from the diff
+
+1. `git log <last-tag>..HEAD --oneline` → group commits by Keep-a-Changelog category.
+2. `git diff <last-tag>..HEAD --stat` → sanity-check which surfaces changed
+   (feeds the API-axis decision in `version-policy.md`).
+3. Read the PR bodies for the impact wording when a commit subject is terse.
+4. Write user-facing prose; drop pure-noise commits (formatting-only, merge commits).

--- a/.claude/skills/prepare-release/references/version-policy.md
+++ b/.claude/skills/prepare-release/references/version-policy.md
@@ -1,0 +1,125 @@
+# Version policy & release mechanics
+
+This repo carries **two independent version axes**. Getting the second one wrong
+is the single most common release mistake, because `npm version` bumps both.
+
+## Table of contents
+
+- [The two axes](#the-two-axes)
+- [Decision: does the API axis move?](#decision-does-the-api-axis-move)
+- [Files touched by each axis](#files-touched-by-each-axis)
+- [Exact bump procedure](#exact-bump-procedure)
+- [Reverting the API axis (the trap)](#reverting-the-api-axis-the-trap)
+- [Known issue: server.json SHA256 mismatch](#known-issue-serverjson-sha256-mismatch)
+
+## The two axes
+
+| Axis | What it means | When it moves |
+|---|---|---|
+| **Package version** | The npm package / MCPB bundle / registry release. Always bumped every release. | **Every** release. |
+| **MCP API version** | Compatibility contract between the Node MCP server and the TD-side Python WebServer. Signals to users whether the `.tox` must be re-imported. | **Only** when the server / API contract actually changes. |
+
+The package version is the number in `package.json`. The API version currently
+sits at `1.4.3` and moves far less often than the package version.
+
+## Decision: does the API axis move?
+
+Answer this **before** bumping. Inspect the unreleased diff
+(`git diff <last-tag>..HEAD --stat`) and ask: *does any change alter the
+server/API contract?*
+
+**API axis MOVES** if the diff changes any of:
+
+- `src/api/**` — the OpenAPI schema (request/response shapes, new endpoints, new
+  params). A change here is the clearest signal the contract moved.
+- `src/features/tools/**` — tool definitions/handlers whose **input or output
+  shape** changes (not internal refactors).
+- `td/modules/mcp/**` — TD-side Python API behavior that the Node side depends on.
+- `src/server/**`, `src/tdClient/**`, `src/transport/**` — protocol/transport
+  behavior visible to a client.
+
+**API axis STAYS PUT** (revert it after bumping) if the diff is only:
+
+- Dependency updates, lockfile changes, `npm audit` fixes.
+- Build/tooling/codegen-toolchain changes with unchanged generated output.
+- Docs, comments, tests, `.claude/**`, CHANGELOG.
+- Pure internal refactors that don't change any request/response shape.
+
+When in doubt, look at whether `td/modules/**` generated output or `src/gen/**`
+changed. If a **client would behave differently**, the axis moves. If not, revert.
+
+> Cross-check: the same path set defines "API/MCP surface" for the
+> `integration-test-guard` hook (`src/api/`, `src/features/tools/`, `src/server/`,
+> `src/tdClient/`, `src/transport/`, `td/modules/mcp/`). If the guard would fire,
+> the API axis very likely moves.
+
+## Files touched by each axis
+
+**Package axis** (`scripts/syncMcpServerVersions.ts`, run by `npm run version:mcp`):
+
+- `package.json` — `version` (bumped by `npm version` itself)
+- `mcpb/manifest.json` — `version`
+- `server.json` — top-level `version`, each package entry `version`, the mcpb
+  `identifier` download URL (`/download/v<ver>/`), and `fileSha256`
+
+**API axis** (`scripts/syncApiServerVersions.ts`, run by `npm run version:api`):
+
+- `src/api/index.yml` — `info.version`
+- `td/modules/utils/version.py` — `MCP_API_VERSION`
+- `pyproject.toml` — `version`
+
+`npm version <level>` runs the `version` npm script, which is
+`run-p version:*` → **both** `version:api` and `version:mcp` fire. That is why
+the API axis needs an explicit revert when it should stay put.
+
+## Exact bump procedure
+
+`version:mcp` reads the freshly built `.mcpb` to compute its SHA256, so the
+bundle must be built **first**.
+
+```bash
+# 1. Build the MCPB bundle first — version:mcp hashes touchdesigner-mcp.mcpb.
+npm run build:mcpb
+
+# 2. Bump. This runs version:api + version:mcp via the `version` script,
+#    writing all six version-bearing files. Choose patch/minor/major.
+npm version patch --no-git-tag-version
+```
+
+`--no-git-tag-version` keeps the commit/tag under the release-PR flow's control
+rather than letting npm tag locally. (Confirm the maintainer's preference; the
+release lands via a `development → main` PR, and tags historically match the
+published `vX.Y.Z`.)
+
+## Reverting the API axis (the trap)
+
+If the [decision](#decision-does-the-api-axis-move) says the API axis stays put,
+restore the three API files to their pre-bump values **after** running
+`npm version`:
+
+```bash
+# Restore API-axis files to the last release's values (they must NOT show the new number).
+git checkout HEAD -- src/api/index.yml td/modules/utils/version.py pyproject.toml
+# Verify they still read the OLD API version (e.g. 1.4.3), not the new package version.
+grep -H version src/api/index.yml pyproject.toml
+grep MCP_API_VERSION td/modules/utils/version.py
+```
+
+The generated `td/modules/td_server/openapi_server/openapi/openapi.yaml` will
+also read the old API version — that is **intended, not stale**.
+
+State the decision explicitly in the CHANGELOG "Changed" entry, e.g.
+*"The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`,
+`pyproject.toml`) stays at `1.4.3` since this release contains no server/API
+contract changes."*
+
+## Known issue: server.json SHA256 mismatch
+
+`server.json`'s `fileSha256` is computed by `version:mcp` from the **locally**
+built `.mcpb`. But `release.yml` **rebuilds** the `.mcpb` after the merge to
+`main` and attaches that to the GitHub Release. The zip build is non-deterministic
+(embeds timestamps), so the published asset's hash will **not** match the recorded
+`fileSha256`. This is a known structural issue (proven on v1.4.7), not something
+to "fix" per-release. Treat it as expected. A real fix would require `release.yml`
+to write the CI-built hash into `server.json` before publishing to the registry —
+propose that as a separate change if asked, don't attempt it inline during a release.

--- a/.claude/skills/release-test-audit/SKILL.md
+++ b/.claude/skills/release-test-audit/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: release-test-audit
+description: >
+  Audit whether the unreleased touchdesigner-mcp diff (since the last tag) is
+  adequately covered by integration tests before a release is cut. Walks every
+  API/MCP surface change in the release range, maps each to the integration suite
+  that should cover it, and reports covered / gap / waived per change. Use before
+  releasing, when checking release test coverage, or when asked whether the
+  release diff "has enough tests". This skill AUDITS coverage across the whole
+  release; it delegates HOW to write or run a test to the `integration-test-guard`
+  skill. Pairs with `prepare-release` and the `release-manager` agent.
+---
+
+# Release test audit
+
+Answer one question for a release: **is every API/MCP surface change in the
+unreleased range covered by an integration test?** This is a release-wide
+completeness check — broader than the per-push `integration-test-guard` hook,
+which only sees one push at a time and can be legitimately skipped commit by
+commit. Across a full release those individual skips can add up to a real gap;
+this audit catches that.
+
+Scope boundary: this skill **finds gaps**. It does **not** teach how to write a
+test — for suite choice, patterns, and run commands, hand off to the
+**`integration-test-guard`** skill.
+
+## Step 1 — enumerate the release's surface changes
+
+```bash
+LAST_TAG=$(git describe --tags --abbrev=0)
+git diff "$LAST_TAG"..HEAD --name-only
+```
+
+Keep only files under the **API/MCP surface** (same paths the guard watches):
+
+```
+src/api/**            OpenAPI schema
+src/features/tools/** tool defs + handlers
+src/server/**         MCP server
+src/tdClient/**       TD HTTP client
+src/transport/**      stdio / HTTP transport
+td/modules/mcp/**     TD-side Python API
+```
+
+Files outside this set (docs, deps, `.claude/**`, build config, pure types) need
+no integration test — list them as **N/A** so the audit is explicit about what it
+skipped.
+
+## Step 2 — map each change to the suite that must cover it
+
+| A surface change in… | Expected suite | Live TD (9981)? |
+|---|---|---|
+| tool **response shape / formatting**, registration, manifest (`src/features/tools/**`, `src/server/**`) | `tests/integration/mcpToolsResponse.test.ts` | No (mocked client) |
+| **client ↔ WebServer behavior** — create/update/delete/exec, TD-side Python (`src/tdClient/**`, `td/modules/mcp/**`, contract in `src/api/**`) | `tests/integration/touchDesignerClientAndWebServer.test.ts` | **Yes** |
+| **HTTP transport** — sessions, `/mcp`, `/health` (`src/transport/**`) | `tests/integration/httpTransport.test.ts` | No (starts HTTP server) |
+
+A change spanning two rows needs coverage in each row's suite.
+
+## Step 3 — check whether coverage actually exists in the release range
+
+For each surface change, verify a **corresponding** test was added or updated in
+the same release range — not just that the suite file exists:
+
+```bash
+# Did the expected suite change in this release range at all?
+git diff "$LAST_TAG"..HEAD --stat -- tests/integration/
+
+# Inspect what changed in the mapped suite, and confirm it exercises THIS change.
+git diff "$LAST_TAG"..HEAD -- tests/integration/<mapped-suite>.test.ts
+```
+
+Coverage is real only if the changed suite exercises the changed behavior. A new
+endpoint with no new/updated assertion in its suite is a **gap**, even if the
+suite file was touched for something else. Prefer reconciliation-style tests
+(compute a value, read it back, compare an invariant) over assertions that pass
+without the behavior working — flag assertion-only additions as weak coverage.
+
+## Step 4 — report the verdict
+
+Emit a table, one row per Step 1 surface change:
+
+| Changed file/area | Expected suite | Status | Note |
+|---|---|---|---|
+| `src/api/paths/api/td/server/exec.yml` | touchDesignerClientAndWebServer | **covered** | reconciles stdout/stderr readback |
+| `td/modules/mcp/services/node_layout.py` | touchDesignerClientAndWebServer | **gap** | no test for grid auto-align |
+
+Status is one of:
+
+- **covered** — a matching test was added/updated in the range and exercises it.
+- **gap** — no matching test, or the suite touched but not for this change.
+- **weak** — a test exists but only asserts shape, not behavior (reconcile instead).
+- **waived** — genuinely needs no integration test (pure refactor / type-only);
+  state why, matching the `SKIP_ITEST_GUARD` rationale the guard would accept.
+
+## Step 5 — close the gaps (delegate)
+
+For every **gap** / **weak** row, hand off to the **`integration-test-guard`**
+skill to pick the suite, write the reconciliation test, and run it. Re-run this
+audit until every surface change is **covered** or explicitly **waived**. Only
+then is the release ready for `prepare-release`.
+
+## Related
+
+- `integration-test-guard` — how to choose/write/run an integration test (this
+  skill delegates the writing to it).
+- `touchdesigner-self-debug` — bring up a real TD + `.tox` for the live-TD suite.
+- `prepare-release` — the release cut that this audit gates.


### PR DESCRIPTION
## Overview


Add `.claude/` tooling to support the release process of touchdesigner-mcp. Standardize the workflow from checking unreleased differences, determining the dual-axis version update policy for MCP/API, creating CHANGELOG diffs, to creating release PRs using skills and a dedicated agent. This does not include changes to product code, versions, or the CHANGELOG itself (only within `.claude/`).


## Additions (3-Layer Structure)


1. `prepare-release` skill — The core workflow for release preparation
- Step 0 Check Diffs → Step 1 Test Audit Gate → Step 2 Dual-axis Version Determination → Step 3 CHANGELOG → Step 4 bump → Step 5 Release PR (`development → main`, `vX.Y.Z`)
- `references/version-policy.md` — Dual-axis version determination logic, list of 6 files, API-axis revert procedure (addressing the pitfall where `npm version` automatically increments the API axis), and known issues regarding non-deterministic SHA256 in `server.json`.
- `references/changelog-format.md` — CHANGELOG house style (template sentence "Released version ... across ...", PR references, categories).


2. `release-test-audit` skill — Integration test coverage audit for all release diffs
- Report changed files → corresponding suites → covered / gap / weak / waived in a table format.
- Defer the test writing method to the existing `integration-test-guard` skill (avoiding duplication). Roles are divided as: guard = gatekeeper for single pushes / audit = inspector for the overall release.


3. `release-manager` agent — A dedicated subagent that drives the above two skills in a fixed order
- Consistently handles from the test audit gate → resolving gaps via `integration-test-guard` → creating a PR via `prepare-release`. Stops once the PR is opened (merging/publishing is left to CI and maintainers).


## Design Points


- The core is the standardization of the error-prone procedure where `npm version` automatically increments the MCP API versions (`src/api/index.yml` / `td/modules/utils/version.py` / `pyproject.toml`), necessitating a `git checkout` to revert them for releases that do not change the server/API contract.
- Keep the SKILL.md body and agent thin by offloading details to references (Progressive Disclosure).


## Verification


- Verified the validity of front matter (`name` / `description`) for all SKILL.md and agents.
- Confirmed that all reference links and cross-referenced skill names (`integration-test-guard`, `touchdesigner-self-debug`) actually exist.

---

## 概要

touchdesigner-mcp のリリース作業を支援する `.claude/` ツーリングを追加する。未リリース差分の確認 → MCP / API の2軸バージョン更新方針の判定 → CHANGELOG 差分作成 → リリースPR作成までを、スキルと専任エージェントで定型化する。プロダクトコード・バージョン・CHANGELOG 本体への変更は含まない（`.claude/` 配下のみ）。

## 追加物（3層構造）

**1. `prepare-release` スキル** — リリース準備の骨格ワークフロー
- Step 0 差分確認 → Step 1 テスト監査ゲート → Step 2 **2軸バージョン判定** → Step 3 CHANGELOG → Step 4 bump → Step 5 リリースPR（`development → main`、`vX.Y.Z`）
- `references/version-policy.md` — 2軸バージョンの判定ロジック、6ファイル一覧、**API軸の戻し手順**（`npm version` が API軸まで自動で上げる罠）、`server.json` SHA256 非決定性の既知問題
- `references/changelog-format.md` — CHANGELOG のハウススタイル（「Released version … across …」定型文、PR参照、カテゴリ）

**2. `release-test-audit` スキル** — リリース差分全体の integration テスト網羅性監査
- 変更ファイル → 対応スイート → covered / gap / weak / waived を表で報告
- テストの**書き方**は既存 `integration-test-guard` スキルに委譲（重複回避）。guard=単一pushの門番／audit=リリース全体の監査官、という役割分担

**3. `release-manager` エージェント** — 上記2スキルを固定順で駆動する専任 subagent
- テスト監査ゲート → gap を `integration-test-guard` で解消 → `prepare-release` でPR作成、まで一貫。開いたPRで停止（merge/publish はCIとメンテナに委ねる）

## 設計上のポイント

- 核心は「`npm version` が MCP API バージョン（`src/api/index.yml` / `td/modules/utils/version.py` / `pyproject.toml`）まで自動で上げてしまうので、サーバー/API契約変更が無いリリースでは `git checkout` で戻す」という、毎回間違えやすい手続きの固定化。
- 詳細は references に逃がし、SKILL.md 本体と agent は薄く保つ（Progressive Disclosure）。

## 検証

- 全 SKILL.md / agent のフロントマター（`name` / `description`）妥当性を確認。
- references リンク・相互参照スキル名（`integration-test-guard`・`touchdesigner-self-debug`）がすべて実在することを確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)