### PR TITLE
feat: add get_top_image tool to capture TOP node output as image (#186)

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -20,6 +20,7 @@ export const TOOL_NAMES = {
 	GET_TD_NODE_ERRORS: "get_td_node_errors",
 	GET_TD_NODE_PARAMETERS: "get_td_node_parameters",
 	GET_TD_NODES: "get_td_nodes",
+	GET_TOP_IMAGE: "get_top_image",
 	UPDATE_TD_NODE_PARAMETERS: "update_td_node_parameters",
 } as const;
 

--- a/src/features/tools/handlers/tdTools.ts
+++ b/src/features/tools/handlers/tdTools.ts
@@ -10,7 +10,7 @@ import {
 	type ToolMetadata,
 } from "../metadata/touchDesignerToolMetadata.js";
 import { formatToolMetadata } from "../presenter/index.js";
-import { TOOL_DEFINITIONS } from "../toolDefinitions.js";
+import { TOOL_DEFINITIONS, type ToolRunResult } from "../toolDefinitions.js";
 import { detailOnlyFormattingSchema } from "../types.js";
 
 const describeToolsSchema = detailOnlyFormattingSchema.extend({
@@ -37,8 +37,8 @@ export function registerTdTools(
 			definition.schema.strict().shape,
 			async (params: Record<string, unknown> = {}) => {
 				try {
-					const text = await definition.run({ logger, params, tdClient });
-					return createToolResult(tdClient, text);
+					const output = await definition.run({ logger, params, tdClient });
+					return createToolResult(tdClient, output);
 				} catch (error) {
 					return handleToolError(
 						error,
@@ -95,11 +95,20 @@ export function registerTdTools(
 
 const createToolResult = (
 	tdClient: TouchDesignerClient,
-	text: string,
+	output: ToolRunResult,
 ): z.infer<typeof CallToolResultSchema> => {
-	const content: z.infer<typeof CallToolResultSchema>["content"] = [
-		{ text, type: "text" as const },
-	];
+	const content: z.infer<typeof CallToolResultSchema>["content"] =
+		typeof output === "string"
+			? [{ text: output, type: "text" as const }]
+			: output.content.map((block) =>
+					block.type === "image"
+						? {
+								data: block.data,
+								mimeType: block.mimeType,
+								type: "image" as const,
+							}
+						: { text: block.text, type: "text" as const },
+				);
 	const additionalContents = tdClient.getAdditionalToolResultContents();
 	if (additionalContents) {
 		content.push(...additionalContents);

--- a/src/features/tools/pythonScripts/getTopImageScript.ts
+++ b/src/features/tools/pythonScripts/getTopImageScript.ts
@@ -1,0 +1,88 @@
+/**
+ * Python script builder for GET_TOP_IMAGE.
+ *
+ * `get_top_image` has no dedicated API endpoint: it reuses the same
+ * `execute_python_script` channel as EXECUTE_PYTHON_SCRIPT. This module only
+ * builds the script text that gets sent over that channel.
+ */
+
+export interface GetTopImageScriptParams {
+	nodePath: string;
+	maxSize?: number;
+}
+
+/**
+ * Builds a Python script that captures the current output of a TOP node as a
+ * base64-encoded JPEG and assigns it to `result` (the variable the TD-side
+ * script executor extracts as the return value).
+ *
+ * When `maxSize` is set and the TOP's longer dimension exceeds it, a
+ * temporary `td.resolutionTOP` is chained onto the node to downscale (aspect
+ * preserved) before capture, then destroyed in a `finally` block so the
+ * project is left unmodified.
+ *
+ * OP type constants are referenced via `td.resolutionTOP` (not the bare
+ * `resolutionTOP` global) because the bare global is only injected into the
+ * exec namespace by TD-side packages that include #185's global injection
+ * fix; `import td` + `td.resolutionTOP` works against both older and newer
+ * deployed `mcp_webserver_base.tox` packages.
+ */
+export function buildGetTopImageScript({
+	nodePath,
+	maxSize,
+}: GetTopImageScriptParams): string {
+	// JSON string literals are valid Python string literals for the characters
+	// that can appear in a node path, so this is a safe way to embed user input.
+	const nodePathLiteral = JSON.stringify(nodePath);
+	const maxSizeLiteral =
+		maxSize === undefined ? "None" : JSON.stringify(maxSize);
+
+	return `import base64
+import td
+
+node_path = ${nodePathLiteral}
+max_size = ${maxSizeLiteral}
+
+node = op(node_path)
+if node is None:
+    raise Exception(f"Node not found at path: {node_path}")
+if node.family != 'TOP':
+    raise Exception(f"Node at {node_path} is not a TOP (family={node.family})")
+
+tmp_top = None
+source_top = node
+try:
+    if max_size is not None:
+        width = node.width
+        height = node.height
+        longest = max(width, height)
+        if longest > max_size:
+            if width >= height:
+                new_w = max_size
+                new_h = max(1, round(height * max_size / width))
+            else:
+                new_h = max_size
+                new_w = max(1, round(width * max_size / height))
+
+            parent = node.parent()
+            tmp_name = '__mcp_tmp_res__' + node.name
+            existing = parent.op(tmp_name)
+            if existing is not None:
+                existing.destroy()
+            tmp_top = parent.create(td.resolutionTOP, tmp_name)
+            tmp_top.inputConnectors[0].connect(node)
+            tmp_top.par.outputresolution = 'custom'
+            tmp_top.par.resolutionw = new_w
+            tmp_top.par.resolutionh = new_h
+            source_top = tmp_top
+
+    byte_array = source_top.saveByteArray('.jpg')
+    if not byte_array:
+        raise Exception(f"Failed to capture image from {node_path}: saveByteArray returned no data")
+
+    result = base64.b64encode(bytes(byte_array)).decode('ascii')
+finally:
+    if tmp_top is not None:
+        tmp_top.destroy()
+`;
+}

--- a/src/features/tools/toolDefinitions.ts
+++ b/src/features/tools/toolDefinitions.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import { z } from "zod";
 import { REFERENCE_COMMENT, TOOL_NAMES } from "../../core/constants.js";
 import type { ILogger } from "../../core/logger.js";
 import {
@@ -29,12 +29,36 @@ import {
 	formatTdInfo,
 	formatUpdateNodeResult,
 } from "./presenter/index.js";
+import { buildGetTopImageScript } from "./pythonScripts/getTopImageScript.js";
 import {
 	detailOnlyFormattingSchema,
 	formattingOptionsSchema,
 } from "./types.js";
 
 export type ToolCategory = "system" | "python" | "nodes" | "classes" | "state";
+
+/** MCP text content block. */
+export interface ToolTextContent {
+	type: "text";
+	text: string;
+}
+
+/** MCP image content block (base64-encoded). */
+export interface ToolImageContent {
+	type: "image";
+	data: string;
+	mimeType: string;
+}
+
+export type ToolContent = ToolTextContent | ToolImageContent;
+
+/**
+ * A tool's `run` normally returns formatter-ready text, which is wrapped in a
+ * single text content block. Tools that need to return non-text content
+ * (e.g. an image) return `{ content }` with the full content block list
+ * instead.
+ */
+export type ToolRunResult = string | { content: ToolContent[] };
 
 /**
  * Single source of truth for a TouchDesigner MCP tool.
@@ -60,8 +84,8 @@ export interface ToolDefinition {
 	notes?: string;
 	/** Optional reference comment appended to error output. */
 	errorComment?: string;
-	/** Executes the tool and returns formatter-ready text. */
-	run: (ctx: ToolRunContext) => Promise<string>;
+	/** Executes the tool and returns formatter-ready text (or explicit content blocks). */
+	run: (ctx: ToolRunContext) => Promise<ToolRunResult>;
 }
 
 export interface ToolRunContext {
@@ -89,7 +113,7 @@ function defineTool<S extends z.ZodObject<z.ZodRawShape>>(def: {
 	example: string;
 	notes?: string;
 	errorComment?: string;
-	run: (ctx: TypedRunContext<S>) => Promise<string>;
+	run: (ctx: TypedRunContext<S>) => Promise<ToolRunResult>;
 }): ToolDefinition {
 	// `run` has a narrower param type (z.infer<S>) than ToolDefinition exposes
 	// (Record<string, unknown>). Function parameters are contravariant, so a
@@ -97,6 +121,27 @@ function defineTool<S extends z.ZodObject<z.ZodRawShape>>(def: {
 	// because params are validated by the MCP SDK before reaching run().
 	return def as unknown as ToolDefinition;
 }
+
+/**
+ * `get_top_image` has no OpenAPI-backed endpoint (see architecture note on
+ * the tool definition below), so its params schema is defined locally
+ * instead of being derived from the generated Zod schemas.
+ */
+const GetTopImageParams = z.object({
+	maxSize: z
+		.number()
+		.int()
+		.positive()
+		.max(4096)
+		.optional()
+		.describe(
+			"Maximum length of the image's longer side in pixels. The TOP is downscaled (aspect ratio preserved) only if it exceeds this value; omit to capture at native resolution.",
+		),
+	nodePath: z
+		.string()
+		.min(1)
+		.describe("Path to the TOP node to capture, e.g. '/project1/moviefilein1'"),
+});
 
 export const TOOL_DEFINITIONS: ToolDefinition[] = [
 	defineTool({
@@ -415,5 +460,43 @@ console.log(docs.helpText?.slice(0, 200));`,
 			});
 		},
 		schema: GetModuleHelpQueryParams.extend(detailOnlyFormattingSchema.shape),
+	}),
+	defineTool({
+		category: "nodes",
+		description:
+			"Capture the current output of a TOP node as an image so it can be viewed directly (maxSize optionally downscales the longer side)",
+		errorComment: REFERENCE_COMMENT,
+		example: `import { getTopImage } from './servers/touchdesigner/getTopImage';
+
+const image = await getTopImage({ nodePath: '/project1/moviefilein1', maxSize: 512 });`,
+		name: TOOL_NAMES.GET_TOP_IMAGE,
+		notes:
+			"Routed through the same Python execution channel as execute_python_script; no dedicated API endpoint exists. When maxSize forces a downscale, a temporary resolutionTOP is created next to the node and always destroyed afterward, so the project is left unmodified.",
+		returns:
+			"An image content block (base64-encoded JPEG) with the captured TOP output.",
+		run: async ({ params, tdClient }) => {
+			const { nodePath, maxSize } = params;
+			const script = buildGetTopImageScript({ maxSize, nodePath });
+			const result = await tdClient.execPythonScript({ script });
+			if (!result.success) {
+				throw result.error;
+			}
+			const base64Data = result.data.result;
+			if (typeof base64Data !== "string" || base64Data.length === 0) {
+				throw new Error(
+					`get_top_image: expected a base64 string result for ${nodePath}, got ${typeof base64Data}`,
+				);
+			}
+			return {
+				content: [
+					{ data: base64Data, mimeType: "image/jpeg", type: "image" },
+					{
+						text: `Captured TOP image from ${nodePath}${maxSize ? ` (maxSize=${maxSize}px)` : ""}.`,
+						type: "text",
+					},
+				],
+			};
+		},
+		schema: GetTopImageParams,
 	}),
 ];

--- a/tests/integration/mcpToolsResponse.test.ts
+++ b/tests/integration/mcpToolsResponse.test.ts
@@ -244,6 +244,65 @@ describe("MCP tool responses", () => {
 		expect(text).toContain("Return type");
 	});
 
+	it("returns an image content block for GET_TOP_IMAGE", async () => {
+		const imageServer = new MockMcpServer();
+		const imageClient = createMockTdClient();
+		imageClient.execPythonScript = (async (_params: unknown) => ({
+			data: { result: "ZmFrZS1qcGVnLWJ5dGVz" },
+			success: true,
+		})) as TouchDesignerClient["execPythonScript"];
+
+		registerTools(
+			imageServer as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+			logger,
+			imageClient,
+		);
+
+		const handler = imageServer.getTool(TOOL_NAMES.GET_TOP_IMAGE);
+		const result = (await handler({
+			maxSize: 256,
+			nodePath: "/project1/top1",
+		})) as {
+			content?: Array<{
+				type: string;
+				data?: string;
+				mimeType?: string;
+				text?: string;
+			}>;
+		};
+
+		const image = result.content?.find((c) => c.type === "image");
+		expect(image?.data).toBe("ZmFrZS1qcGVnLWJ5dGVz");
+		expect(image?.mimeType).toBe("image/jpeg");
+		const text = result.content?.find((c) => c.type === "text")?.text ?? "";
+		expect(text).toContain("/project1/top1");
+	});
+
+	it("returns an error response when GET_TOP_IMAGE targets a non-existent node", async () => {
+		const failingServer = new MockMcpServer();
+		const failingClient = createMockTdClient();
+		failingClient.execPythonScript = (async (_params: unknown) => ({
+			error: new Error("Node not found at path: /project1/missing"),
+			success: false,
+		})) as TouchDesignerClient["execPythonScript"];
+
+		registerTools(
+			failingServer as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+			logger,
+			failingClient,
+		);
+
+		const handler = failingServer.getTool(TOOL_NAMES.GET_TOP_IMAGE);
+		const result = (await handler({ nodePath: "/project1/missing" })) as {
+			content?: Array<{ type: string; text?: string }>;
+			isError?: boolean;
+		};
+
+		expect(result.isError).toBe(true);
+		const text = result.content?.find((c) => c.type === "text")?.text ?? "";
+		expect(text).toContain("Node not found at path: /project1/missing");
+	});
+
 	it("returns filesystem manifest for DESCRIBE_TD_TOOLS", async () => {
 		const handler = server.getTool(TOOL_NAMES.DESCRIBE_TD_TOOLS);
 		const result = (await handler({

--- a/tests/unit/getTopImageTool.test.ts
+++ b/tests/unit/getTopImageTool.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from "vitest";
+import { TOOL_NAMES } from "../../src/core/constants.js";
+import type { ILogger } from "../../src/core/logger.js";
+import { TOOL_DEFINITIONS } from "../../src/features/tools/toolDefinitions.js";
+import type { TouchDesignerClient } from "../../src/tdClient/touchDesignerClient.js";
+
+const nullLogger: ILogger = {
+	sendLog: () => {},
+};
+
+function getDefinition() {
+	const definition = TOOL_DEFINITIONS.find(
+		(d) => d.name === TOOL_NAMES.GET_TOP_IMAGE,
+	);
+	if (!definition) {
+		throw new Error("get_top_image tool definition not found");
+	}
+	return definition;
+}
+
+describe("get_top_image tool definition", () => {
+	it("is registered with a nodePath-only + maxSize schema", () => {
+		const definition = getDefinition();
+		expect(definition.category).toBe("nodes");
+		const shape = definition.schema.shape;
+		expect(Object.keys(shape).sort()).toEqual(["maxSize", "nodePath"]);
+	});
+
+	it("returns an image content block built from the base64 script result", async () => {
+		const definition = getDefinition();
+		const execPythonScript = vi.fn().mockResolvedValue({
+			data: { result: "ZmFrZS1qcGVnLWJ5dGVz" },
+			success: true,
+		});
+		const tdClient = {
+			execPythonScript,
+		} as unknown as TouchDesignerClient;
+
+		const output = await definition.run({
+			logger: nullLogger,
+			params: { maxSize: 512, nodePath: "/project1/top1" },
+			tdClient,
+		});
+
+		expect(execPythonScript).toHaveBeenCalledTimes(1);
+		const [{ script }] = execPythonScript.mock.calls[0] as [{ script: string }];
+		expect(script).toContain('node_path = "/project1/top1"');
+		expect(script).toContain("max_size = 512");
+
+		if (typeof output === "string") {
+			throw new Error("expected a content block result, got a string");
+		}
+		expect(output.content).toEqual([
+			{
+				data: "ZmFrZS1qcGVnLWJ5dGVz",
+				mimeType: "image/jpeg",
+				type: "image",
+			},
+			{
+				text: "Captured TOP image from /project1/top1 (maxSize=512px).",
+				type: "text",
+			},
+		]);
+	});
+
+	it("throws the underlying error when execPythonScript fails", async () => {
+		const definition = getDefinition();
+		const tdClient = {
+			execPythonScript: vi.fn().mockResolvedValue({
+				error: new Error("Node not found at path: /project1/missing"),
+				success: false,
+			}),
+		} as unknown as TouchDesignerClient;
+
+		await expect(
+			definition.run({
+				logger: nullLogger,
+				params: { nodePath: "/project1/missing" },
+				tdClient,
+			}),
+		).rejects.toThrow("Node not found at path: /project1/missing");
+	});
+
+	it("throws a clear error when the script result is not a base64 string", async () => {
+		const definition = getDefinition();
+		const tdClient = {
+			execPythonScript: vi.fn().mockResolvedValue({
+				data: { result: null },
+				success: true,
+			}),
+		} as unknown as TouchDesignerClient;
+
+		await expect(
+			definition.run({
+				logger: nullLogger,
+				params: { nodePath: "/project1/top1" },
+				tdClient,
+			}),
+		).rejects.toThrow(/expected a base64 string result/);
+	});
+});

--- a/tests/unit/pythonScripts/getTopImageScript.test.ts
+++ b/tests/unit/pythonScripts/getTopImageScript.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildGetTopImageScript } from "../../../src/features/tools/pythonScripts/getTopImageScript.js";
+
+describe("buildGetTopImageScript", () => {
+	it("embeds the node path as a Python string literal", () => {
+		const script = buildGetTopImageScript({ nodePath: "/project1/text1" });
+		expect(script).toContain('node_path = "/project1/text1"');
+	});
+
+	it("escapes quotes and backslashes safely via JSON string encoding", () => {
+		const script = buildGetTopImageScript({
+			nodePath: '/project1/weird"name\\here',
+		});
+		expect(script).toContain('node_path = "/project1/weird\\"name\\\\here"');
+	});
+
+	it("sets max_size to None when maxSize is omitted", () => {
+		const script = buildGetTopImageScript({ nodePath: "/project1/top1" });
+		expect(script).toContain("max_size = None");
+	});
+
+	it("sets max_size to the numeric literal when provided", () => {
+		const script = buildGetTopImageScript({
+			maxSize: 512,
+			nodePath: "/project1/top1",
+		});
+		expect(script).toContain("max_size = 512");
+	});
+
+	it("includes TOP validation, downscale, and cleanup logic", () => {
+		const script = buildGetTopImageScript({
+			maxSize: 256,
+			nodePath: "/project1/top1",
+		});
+		expect(script).toContain("node.family != 'TOP'");
+		// `td.resolutionTOP` (not the bare `resolutionTOP` global) so this also
+		// works against TD-side packages predating the #185 namespace injection.
+		expect(script).toContain("import td");
+		expect(script).toContain("td.resolutionTOP");
+		expect(script).toContain("saveByteArray('.jpg')");
+		expect(script).toContain("base64.b64encode");
+		expect(script).toContain("tmp_top.destroy()");
+		// Cleanup must be unconditional so the project is never left dirty.
+		expect(script).toContain("finally:");
+	});
+
+	it("assigns the base64 string to `result`, the variable the TD executor extracts", () => {
+		const script = buildGetTopImageScript({ nodePath: "/project1/top1" });
+		expect(script).toMatch(/result = base64\.b64encode/);
+	});
+});


### PR DESCRIPTION
## Summary
Implements the client-side `get_top_image` tool discussed in #186. Captures the current output of a TOP node as a JPEG image and returns it as an MCP image content block, so MCP clients (LLMs) can visually inspect TOP outputs for autonomous debugging.

As agreed in the issue, **no new API endpoint is added** — the tool sends a Python script through the existing exec route (`saveByteArray('.jpg')` → base64 → image content block on the npm side).

## Changes
- New `get_top_image` tool: `nodePath` (required), `maxSize` (optional, positive int ≤ 4096; downscales the longer side via a temporary `resolutionTOP`, destroyed in `finally`)
- Generalized `ToolDefinition.run` return type to `string | {content: ToolContent[]}` so tools can return content blocks (existing 11 tools unchanged)
- The generated script uses `import td` / `td.resolutionTOP`, so it works both with currently-distributed TD-side packages (no globals injection) and with post-#191 builds
- Unit tests for script generation and the tool handler; integration test for the registered handler

## Verification
- `npx tsc --noEmit` / `npm run lint` (biome, tsc, ruff, prettier): pass
- `npm run test:unit`: 254/254 pass
- E2E against live TouchDesigner 2025.32820 (macOS, TD-side package 1.4.12):
  - 720x1280 TOP with `maxSize: 512` → valid 288x512 JPEG, correct content, no leftover temp nodes
  - without `maxSize` → full-resolution 720x1280 JPEG
  - non-TOP path / missing path → clear error messages via the standard error response

Closes #186
