### PR TITLE
v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-07-11
+
+### Added
+
+- Added a new `get_top_image` MCP tool that captures the current output of any TOP node as a JPEG and returns it as an MCP image content block, so AI agents can actually see what a TOP is rendering instead of reasoning blind about visual output. An optional `maxSize` parameter downscales the longer side while preserving aspect ratio; when a downscale is needed, a temporary `resolutionTOP` is created next to the node and always destroyed afterward, leaving the project unmodified. The capture is routed through the same Python execution channel as `execute_python_script`, so no new HTTP endpoint is required ([#186](https://github.com/8beeeaaat/touchdesigner-mcp/issues/186), [#195](https://github.com/8beeeaaat/touchdesigner-mcp/pull/195)).
+- Newly created nodes are now automatically placed on a non-overlapping grid instead of stacking at TouchDesigner's default position, so networks built through repeated `create_td_node` calls stay readable. Existing nodes are never moved, an explicit `nodeX`/`nodeY` supplied by the caller is respected over auto-alignment, and a placement failure only logs a warning without failing node creation ([#187](https://github.com/8beeeaaat/touchdesigner-mcp/pull/187)).
+
+### Fixed
+
+- `execute_python_script` responses now surface captured `print` output: the TouchDesigner side returns captured output under the `stdout`/`stderr` keys, but the response formatter read a nonexistent `output` key, so print output was silently dropped in summary/minimal responses. The keys are now read correctly, a `Stderr` section is rendered when scripts write to standard error, and the exec endpoint's OpenAPI schema documents both fields ([#183](https://github.com/8beeeaaat/touchdesigner-mcp/issues/183), [#189](https://github.com/8beeeaaat/touchdesigner-mcp/pull/189)).
+- `execute_python_script` error responses now include the full Python traceback instead of only the exception message, so failures inside TouchDesigner can be located without re-running the script with manual instrumentation ([#184](https://github.com/8beeeaaat/touchdesigner-mcp/issues/184), [#190](https://github.com/8beeeaaat/touchdesigner-mcp/pull/190)).
+- `execute_python_script` now exposes TouchDesigner's global namespace (`tdu`, `absTime`, `ui`, OP type names such as `noiseTOP`, `ParMode`, ...) by merging the `__main__` module globals into the script namespace, so code copy-pasted from the Textport or a DAT runs unchanged instead of raising `NameError` ([#185](https://github.com/8beeeaaat/touchdesigner-mcp/issues/185), [#191](https://github.com/8beeeaaat/touchdesigner-mcp/pull/191)).
+
+### Changed
+
+- Released version `1.5.0` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB download URL and checksum so npm and MCPB installations resolve the same release. The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) is bumped from `1.4.3` to `1.5.0` because this release changes the server/API contract: the exec endpoint response gains `stdout`/`stderr` fields, TD-side script execution behavior changed (traceback in errors, TouchDesigner globals in the namespace, node auto-alignment), and the new `get_top_image` tool was added. Re-import `td/mcp_webserver_base.tox` (or update the `td/modules` files) so the TouchDesigner side runs the new contract. No dependency updates are included.
+
+### Technical
+
+- Expanded integration coverage for the release surface: live-TD reconciliation tests for Python script execution (stdout/stderr capture, traceback propagation, TouchDesigner globals), node auto-alignment (zero-overlap readback, explicit-coordinate override), and `get_top_image` (JPEG dimensions at native and `maxSize`-constrained resolution, temp-TOP cleanup, non-TOP family error), plus a mocked MCP-response test asserting the `execute_python_script` tool renders captured stdout/stderr ([#193](https://github.com/8beeeaaat/touchdesigner-mcp/pull/193), [#196](https://github.com/8beeeaaat/touchdesigner-mcp/pull/196)).
+- Added release tooling for maintainers: an `integration-test-guard` pre-push hook + skill that blocks pushes touching the API/MCP surface without integration-test changes, and a release-manager agent with `prepare-release` / `release-test-audit` skills encoding the two-axis version policy and the release flow ([#188](https://github.com/8beeeaaat/touchdesigner-mcp/pull/188), [#192](https://github.com/8beeeaaat/touchdesigner-mcp/pull/192)).
+
 ## [1.4.12] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expanded integration coverage for the release surface: live-TD reconciliation tests for Python script execution (stdout/stderr capture, traceback propagation, TouchDesigner globals), node auto-alignment (zero-overlap readback, explicit-coordinate override), and `get_top_image` (JPEG dimensions at native and `maxSize`-constrained resolution, temp-TOP cleanup, non-TOP family error), plus a mocked MCP-response test asserting the `execute_python_script` tool renders captured stdout/stderr ([#193](https://github.com/8beeeaaat/touchdesigner-mcp/pull/193), [#196](https://github.com/8beeeaaat/touchdesigner-mcp/pull/196)).
 - Added release tooling for maintainers: an `integration-test-guard` pre-push hook + skill that blocks pushes touching the API/MCP surface without integration-test changes, and a release-manager agent with `prepare-release` / `release-test-audit` skills encoding the two-axis version policy and the release flow ([#188](https://github.com/8beeeaaat/touchdesigner-mcp/pull/188), [#192](https://github.com/8beeeaaat/touchdesigner-mcp/pull/192)).
 
+### Contributors
+
+- [@jmworks](https://github.com/jmworks) — `get_top_image` tool ([#195](https://github.com/8beeeaaat/touchdesigner-mcp/pull/195)); `execute_python_script` fixes: stdout/stderr display ([#189](https://github.com/8beeeaaat/touchdesigner-mcp/pull/189)), traceback in error responses ([#190](https://github.com/8beeeaaat/touchdesigner-mcp/pull/190)), TouchDesigner globals in the script namespace ([#191](https://github.com/8beeeaaat/touchdesigner-mcp/pull/191))
+- [@8beeeaaat](https://github.com/8beeeaaat) — node auto-alignment ([#187](https://github.com/8beeeaaat/touchdesigner-mcp/pull/187)); integration tests for Python script execution ([#193](https://github.com/8beeeaaat/touchdesigner-mcp/pull/193)) and live-TD `get_top_image` coverage ([#196](https://github.com/8beeeaaat/touchdesigner-mcp/pull/196)); integration-test-guard hook and release tooling ([#188](https://github.com/8beeeaaat/touchdesigner-mcp/pull/188), [#192](https://github.com/8beeeaaat/touchdesigner-mcp/pull/192))
+
 ## [1.4.12] - 2026-07-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.5.0] - 2026-07-11
 
+### Upgrade Notes
+
+What existing users can expect when the MCP server updates before the TouchDesigner component does:
+
+- **The server side updates itself; nothing breaks.** Configurations using `npx -y touchdesigner-mcp-server@latest` pick up 1.5.0 on the next MCP client restart. The server performs a version handshake with the TouchDesigner component and keeps operating against an older `mcp_webserver_base.tox` (API 1.3.0–1.4.x): all existing tools continue to work, and an "Update Recommended" notice with re-import instructions is appended to every tool response until the component is updated.
+- **Available immediately, without re-importing the `.tox`:** the new `get_top_image` tool (its capture script is written to run on older deployed components) and the `execute_python_script` stdout/stderr display fix ([#189](https://github.com/8beeeaaat/touchdesigner-mcp/pull/189) — the bug was on the Node.js side; TouchDesigner components have returned captured output all along).
+- **Requires re-importing `td/mcp_webserver_base.tox`:** full Python tracebacks in error responses ([#190](https://github.com/8beeeaaat/touchdesigner-mcp/pull/190)), TouchDesigner globals in the script namespace ([#191](https://github.com/8beeeaaat/touchdesigner-mcp/pull/191)), and node auto-alignment ([#187](https://github.com/8beeeaaat/touchdesigner-mcp/pull/187)). Re-importing also clears the per-response update notice.
+- Components older than v1.3.0 (which predate version reporting) are rejected at connection time, as in previous releases — update both the server and the component.
+
 ### Added
 
 - Added a new `get_top_image` MCP tool that captures the current output of any TOP node as a JPEG and returns it as an MCP image content block, so AI agents can actually see what a TOP is rendering instead of reasoning blind about visual output. An optional `maxSize` parameter downscales the longer side while preserving aspect ratio; when a downscale is needed, a temporary `resolutionTOP` is created next to the node and always destroyed afterward, leaving the project unmodified. The capture is routed through the same Python execution channel as `execute_python_script`, so no new HTTP endpoint is required ([#186](https://github.com/8beeeaaat/touchdesigner-mcp/issues/186), [#195](https://github.com/8beeeaaat/touchdesigner-mcp/pull/195)).

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.4.12",
+  "version": "1.5.0",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",
@@ -74,6 +74,10 @@
     {
       "name": "get_td_nodes",
       "description": "List nodes in TouchDesigner with filtering options"
+    },
+    {
+      "name": "get_top_image",
+      "description": "Capture the current output of a TOP node as a JPEG image, optionally downscaled to a maximum size"
     },
     {
       "name": "update_td_node_parameters",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.12",
+	"version": "1.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.4.12",
+			"version": "1.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/sdk": "1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.4.12",
+	"version": "1.5.0",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "touchdesigner-mcp"
-version = "1.4.3"
+version = "1.5.0"
 description = "TouchDesigner MCP Server - Python modules"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.8beeeaaat/touchdesigner-mcp-server",
   "description": "MCP server for TouchDesigner - Control and operate TouchDesigner projects through AI agents",
-  "version": "1.4.12",
+  "version": "1.5.0",
   "repository": {
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "touchdesigner-mcp-server",
-      "version": "1.4.12",
+      "version": "1.5.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -19,9 +19,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.4.12/touchdesigner-mcp.mcpb",
-      "version": "1.4.12",
-      "fileSha256": "355eb9b74a0c34ab8b8725035866040c8c431eb052c4cb473af7d4e3b410cb6a",
+      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.5.0/touchdesigner-mcp.mcpb",
+      "version": "1.5.0",
+      "fileSha256": "10d021b61c8d7fedd55cc0c0c64d3651c475a4fcab6f1e4f8aa7eb2b0a117b97",
       "transport": {
         "type": "stdio"
       }

--- a/src/api/index.yml
+++ b/src/api/index.yml
@@ -1,7 +1,7 @@
 info:
   description: OpenAPI schema for generating TouchDesigner API client code
   title: TouchDesigner API
-  version: 1.4.3
+  version: 1.5.0
 
 openapi: 3.0.0
 

--- a/td/modules/utils/version.py
+++ b/td/modules/utils/version.py
@@ -2,7 +2,7 @@
 Version utilities shared across TouchDesigner MCP Python modules.
 """
 
-MCP_API_VERSION = "1.4.3"
+MCP_API_VERSION = "1.5.0"
 
 
 def get_mcp_api_version() -> str:

--- a/tests/integration/mcpToolsResponse.test.ts
+++ b/tests/integration/mcpToolsResponse.test.ts
@@ -244,6 +244,42 @@ describe("MCP tool responses", () => {
 		expect(text).toContain("Return type");
 	});
 
+	it("renders captured stdout and stderr for EXECUTE_PYTHON_SCRIPT", async () => {
+		const scriptServer = new MockMcpServer();
+		const scriptClient = createMockTdClient();
+		// Real WebServer responses carry captured output under the keys
+		// "stdout" / "stderr" (see exec.yml) — assert the handler → formatter
+		// path renders both sections from those exact keys.
+		scriptClient.execPythonScript = (async (_params: unknown) => ({
+			data: {
+				result: "done",
+				stderr: "oops stderr",
+				stdout: "hello stdout",
+			},
+			success: true,
+		})) as TouchDesignerClient["execPythonScript"];
+
+		registerTools(
+			scriptServer as unknown as import("@modelcontextprotocol/sdk/server/mcp.js").McpServer,
+			logger,
+			scriptClient,
+		);
+
+		const handler = scriptServer.getTool(TOOL_NAMES.EXECUTE_PYTHON_SCRIPT);
+		const result = (await handler({
+			detailLevel: "summary",
+			responseFormat: "markdown",
+			script: "print('hello stdout')",
+		})) as {
+			content?: Array<{ type: string; text?: string }>;
+		};
+		const text = result.content?.find((c) => c.type === "text")?.text ?? "";
+		expect(text).toContain("Output:");
+		expect(text).toContain("hello stdout");
+		expect(text).toContain("Stderr:");
+		expect(text).toContain("oops stderr");
+	});
+
 	it("returns an image content block for GET_TOP_IMAGE", async () => {
 		const imageServer = new MockMcpServer();
 		const imageClient = createMockTdClient();


### PR DESCRIPTION
## [1.5.0] - 2026-07-11

### Upgrade Notes

What existing users can expect when the MCP server updates before the TouchDesigner component does:

- **The server side updates itself; nothing breaks.** Configurations using `npx -y touchdesigner-mcp-server@latest` pick up 1.5.0 on the next MCP client restart. The server performs a version handshake with the TouchDesigner component and keeps operating against an older `mcp_webserver_base.tox` (API 1.3.0–1.4.x): all existing tools continue to work, and an "Update Recommended" notice with re-import instructions is appended to every tool response until the component is updated.
- **Available immediately, without re-importing the `.tox`:** the new `get_top_image` tool (its capture script is written to run on older deployed components) and the `execute_python_script` stdout/stderr display fix ([#189](https://github.com/8beeeaaat/touchdesigner-mcp/pull/189) — the bug was on the Node.js side; TouchDesigner components have returned captured output all along).
- **Requires re-importing `td/mcp_webserver_base.tox`:** full Python tracebacks in error responses ([#190](https://github.com/8beeeaaat/touchdesigner-mcp/pull/190)), TouchDesigner globals in the script namespace ([#191](https://github.com/8beeeaaat/touchdesigner-mcp/pull/191)), and node auto-alignment ([#187](https://github.com/8beeeaaat/touchdesigner-mcp/pull/187)). Re-importing also clears the per-response update notice.
- Components older than v1.3.0 (which predate version reporting) are rejected at connection time, as in previous releases — update both the server and the component.

### Added

- Added a new `get_top_image` MCP tool that captures the current output of any TOP node as a JPEG and returns it as an MCP image content block, so AI agents can actually see what a TOP is rendering instead of reasoning blind about visual output. An optional `maxSize` parameter downscales the longer side while preserving aspect ratio; when a downscale is needed, a temporary `resolutionTOP` is created next to the node and always destroyed afterward, leaving the project unmodified. The capture is routed through the same Python execution channel as `execute_python_script`, so no new HTTP endpoint is required ([#186](https://github.com/8beeeaaat/touchdesigner-mcp/issues/186), [#195](https://github.com/8beeeaaat/touchdesigner-mcp/pull/195)).
- Newly created nodes are now automatically placed on a non-overlapping grid instead of stacking at TouchDesigner's default position, so networks built through repeated `create_td_node` calls stay readable. Existing nodes are never moved, an explicit `nodeX`/`nodeY` supplied by the caller is respected over auto-alignment, and a placement failure only logs a warning without failing node creation ([#187](https://github.com/8beeeaaat/touchdesigner-mcp/pull/187)).

### Fixed

- `execute_python_script` responses now surface captured `print` output: the TouchDesigner side returns captured output under the `stdout`/`stderr` keys, but the response formatter read a nonexistent `output` key, so print output was silently dropped in summary/minimal responses. The keys are now read correctly, a `Stderr` section is rendered when scripts write to standard error, and the exec endpoint's OpenAPI schema documents both fields ([#183](https://github.com/8beeeaaat/touchdesigner-mcp/issues/183), [#189](https://github.com/8beeeaaat/touchdesigner-mcp/pull/189)).
- `execute_python_script` error responses now include the full Python traceback instead of only the exception message, so failures inside TouchDesigner can be located without re-running the script with manual instrumentation ([#184](https://github.com/8beeeaaat/touchdesigner-mcp/issues/184), [#190](https://github.com/8beeeaaat/touchdesigner-mcp/pull/190)).
- `execute_python_script` now exposes TouchDesigner's global namespace (`tdu`, `absTime`, `ui`, OP type names such as `noiseTOP`, `ParMode`, ...) by merging the `__main__` module globals into the script namespace, so code copy-pasted from the Textport or a DAT runs unchanged instead of raising `NameError` ([#185](https://github.com/8beeeaaat/touchdesigner-mcp/issues/185), [#191](https://github.com/8beeeaaat/touchdesigner-mcp/pull/191)).

### Changed

- Released version `1.5.0` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB download URL and checksum so npm and MCPB installations resolve the same release. The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) is bumped from `1.4.3` to `1.5.0` because this release changes the server/API contract: the exec endpoint response gains `stdout`/`stderr` fields, TD-side script execution behavior changed (traceback in errors, TouchDesigner globals in the namespace, node auto-alignment), and the new `get_top_image` tool was added. Re-import `td/mcp_webserver_base.tox` (or update the `td/modules` files) so the TouchDesigner side runs the new contract. No dependency updates are included.

### Technical

- Expanded integration coverage for the release surface: live-TD reconciliation tests for Python script execution (stdout/stderr capture, traceback propagation, TouchDesigner globals), node auto-alignment (zero-overlap readback, explicit-coordinate override), and `get_top_image` (JPEG dimensions at native and `maxSize`-constrained resolution, temp-TOP cleanup, non-TOP family error), plus a mocked MCP-response test asserting the `execute_python_script` tool renders captured stdout/stderr ([#193](https://github.com/8beeeaaat/touchdesigner-mcp/pull/193), [#196](https://github.com/8beeeaaat/touchdesigner-mcp/pull/196)).
- Added release tooling for maintainers: an `integration-test-guard` pre-push hook + skill that blocks pushes touching the API/MCP surface without integration-test changes, and a release-manager agent with `prepare-release` / `release-test-audit` skills encoding the two-axis version policy and the release flow ([#188](https://github.com/8beeeaaat/touchdesigner-mcp/pull/188), [#192](https://github.com/8beeeaaat/touchdesigner-mcp/pull/192)).

### Contributors

- [@jmworks](https://github.com/jmworks) — `get_top_image` tool ([#195](https://github.com/8beeeaaat/touchdesigner-mcp/pull/195)); `execute_python_script` fixes: stdout/stderr display ([#189](https://github.com/8beeeaaat/touchdesigner-mcp/pull/189)), traceback in error responses ([#190](https://github.com/8beeeaaat/touchdesigner-mcp/pull/190)), TouchDesigner globals in the script namespace ([#191](https://github.com/8beeeaaat/touchdesigner-mcp/pull/191))
- [@8beeeaaat](https://github.com/8beeeaaat) — node auto-alignment ([#187](https://github.com/8beeeaaat/touchdesigner-mcp/pull/187)); integration tests for Python script execution ([#193](https://github.com/8beeeaaat/touchdesigner-mcp/pull/193)) and live-TD `get_top_image` coverage ([#196](https://github.com/8beeeaaat/touchdesigner-mcp/pull/196)); integration-test-guard hook and release tooling ([#188](https://github.com/8beeeaaat/touchdesigner-mcp/pull/188), [#192](https://github.com/8beeeaaat/touchdesigner-mcp/pull/192))

