### PR TITLE
feat: port release tooling to Codex and formalize Upgrade Notes / Contributors changelog sections

### DIFF
--- a/.agents/skills/integration-test-guard
+++ b/.agents/skills/integration-test-guard
@@ -1,0 +1,1 @@
+../../.claude/skills/integration-test-guard

--- a/.agents/skills/prepare-release
+++ b/.agents/skills/prepare-release
@@ -1,0 +1,1 @@
+../../.claude/skills/prepare-release

--- a/.agents/skills/release-test-audit
+++ b/.agents/skills/release-test-audit
@@ -1,0 +1,1 @@
+../../.claude/skills/release-test-audit

--- a/.agents/skills/touchdesigner-self-debug
+++ b/.agents/skills/touchdesigner-self-debug
@@ -1,0 +1,1 @@
+../../.claude/skills/touchdesigner-self-debug

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -42,10 +42,12 @@ owns the exact procedure — trust it, don't improvise version edits.
    while any surface change is an unwaived gap.**
 
 3. **Cut the release.** Invoke the **`prepare-release`** skill: decide both
-   version axes from the diff, write the CHANGELOG entry, build the MCPB bundle,
-   `npm version`, revert the API axis if it stays put, verify the version split,
-   commit, and open the `development → main` PR (title `vX.Y.Z`, body = the new
-   CHANGELOG section).
+   version axes from the diff, write the CHANGELOG entry (leading with
+   `### Upgrade Notes` when the API axis moves, closing with `### Contributors`
+   crediting every human contributor — see the skill's changelog-format
+   reference), build the MCPB bundle, `npm version`, revert the API axis if it
+   stays put, verify the version split, commit, and open the
+   `development → main` PR (title `vX.Y.Z`, body = the new CHANGELOG section).
 
 4. **Report and stop.** Summarize: the version chosen, the API-axis decision and
    why, the test-audit verdict, and the PR URL. Do not merge or publish.

--- a/.claude/hooks/integration-test-guard.mjs
+++ b/.claude/hooks/integration-test-guard.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// PreToolUse(Bash) guard: block `git push` when the outgoing commits change
+// Claude/Codex PreToolUse(Bash) guard: block `git push` when outgoing commits change
 // MCP/API source without an accompanying integration test change.
 //
 // Checked at push time (not commit time) so the gate fires once, right before
@@ -42,9 +42,11 @@ function git(args, cwd) {
 }
 
 const raw = await readStdin();
+let input = {};
 let cmd = "";
 try {
-	cmd = String((JSON.parse(raw).tool_input || {}).command || "");
+	input = JSON.parse(raw);
+	cmd = String((input.tool_input || {}).command || "");
 } catch {}
 
 // Only act on git push.
@@ -54,7 +56,7 @@ if (!cmd.includes("git push")) process.exit(0);
 if (/--delete|--tags|SKIP_ITEST_GUARD/.test(cmd)) process.exit(0);
 if (process.env.SKIP_ITEST_GUARD === "1") process.exit(0);
 
-const cwd = process.env.CLAUDE_PROJECT_DIR || process.cwd();
+const cwd = input.cwd || process.env.CLAUDE_PROJECT_DIR || process.cwd();
 
 // Determine the base of the outgoing range (what this push will add).
 let base = git(

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -64,6 +64,15 @@ Step 0 commits into Keep-a-Changelog sections, write impact-first prose, referen
 the merged PRs, and include the mandatory "Released version … across …" bullet
 whose last sentence records the Step 2 API-axis decision.
 
+Two sections bracket the entry (both defined in changelog-format.md):
+
+- **`### Upgrade Notes` first** — required whenever the API axis moves, and
+  whenever the release otherwise changes what existing users experience. Derive
+  it from the Node-side vs TD-side split of the diff.
+- **`### Contributors` last** — credit every human contributor, cross-checking
+  commit authors, `Co-Authored-By` trailers, and PR authors (squash merges can
+  hide a contributor behind the maintainer's commit email).
+
 ## Step 4 — bump the version-bearing files
 
 Per [references/version-policy.md](references/version-policy.md):

--- a/.claude/skills/prepare-release/references/changelog-format.md
+++ b/.claude/skills/prepare-release/references/changelog-format.md
@@ -9,6 +9,9 @@
 ```markdown
 ## [X.Y.Z] - YYYY-MM-DD
 
+### Upgrade Notes
+- <what existing users must know/do — see rule below>
+
 ### Added
 - <new user-facing capability>
 
@@ -27,10 +30,14 @@
 ### Technical
 - **Dependency Updates**: <what & why>
   - `pkg` old → new
+
+### Contributors
+- [@login](https://github.com/login) — <contribution> ([#N](https://github.com/8beeeaaat/touchdesigner-mcp/pull/N))
 ```
 
-Include only the sections that apply, in the order above (Added, Changed, Fixed,
-Removed, Security, Technical). Put the newest entry at the top of the file.
+Include only the sections that apply, in the order above (Upgrade Notes first,
+then Added, Changed, Fixed, Removed, Security, Technical, Contributors last).
+Put the newest entry at the top of the file.
 
 ## House-style rules (observed across 1.4.x)
 
@@ -60,6 +67,34 @@ Removed, Security, Technical). Put the newest entry at the top of the file.
 + **Dependency updates** go under `### Technical` as a `**Dependency Updates**:`
   bullet with an indented `old → new` list. If there are none, say so explicitly
   ("No dependency updates are included.").
++ **Upgrade Notes lead the entry** whenever the release changes what existing
+  users experience — mandatory when the API axis moves (introduced in 1.5.0).
+  Readers want "do I have to do anything?" answered first, so this section goes
+  before `### Added`. Derive it from the Node-side / TD-side split of the diff:
+  - The server side self-updates: the documented config is
+    `npx -y touchdesigner-mcp-server@latest`, so users pick the release up on
+    the next MCP client restart. Same-major/newer-minor against an older `.tox`
+    is **not** a failure — the version handshake continues and appends an
+    "Update Recommended" notice to every tool response
+    (see `src/core/compatibility.ts`).
+  - List what works **without** re-importing the `.tox`: Node-side-only changes
+    (formatter/client fixes, tools routed through the existing
+    `execute_python_script` channel).
+  - List what **requires** re-importing `td/mcp_webserver_base.tox`: anything
+    under `td/modules/**` — those files are baked into the `.tox`.
+  - Note hard rejections: components older than
+    `mcpCompatibility.minApiVersion` (`package.json`) are refused at connection
+    time.
+  Verify the split against the actual compatibility policy in
+  `src/core/compatibility.ts` instead of assuming it.
++ **Contributors close the entry** (introduced in 1.5.0). Credit every human
+  contributor in the release range as
+  `- [@login](https://github.com/login) — <contribution> ([#N](…/pull/N))`.
+  Identify contributors by cross-checking **three** sources — commit authors
+  (`git log --format='%an %ae'`), `Co-Authored-By` trailers, and the PR author
+  (`gh pr view <n> --json author`) — because squash merges can land a
+  contributor's PR under the maintainer's commit email. Exclude bots and
+  AI-assistant co-author trailers.
 
 ## Deriving the content from the diff
 

--- a/.codex/agents/release-manager.toml
+++ b/.codex/agents/release-manager.toml
@@ -1,0 +1,14 @@
+name = "release-manager"
+description = "Own the touchdesigner-mcp release from an unreleased diff through an opened development-to-main release PR. Use for release, cut a release, prepare vX.Y.Z, or ship pending changes requests."
+developer_instructions = """
+Take touchdesigner-mcp from unreleased commits to an open release PR. Do not merge, tag, publish, or run npm publish; CI releases only after a maintainer merges the PR.
+
+Follow this order:
+
+1. Run `git fetch --tags`, identify the last tag, and inspect `<tag>..HEAD`. Stop if the range is empty.
+2. Use the `release-test-audit` skill. Resolve every gap or weak result with the `integration-test-guard` skill, then re-audit. Do not bump while an API/MCP surface gap remains unwaived.
+3. Use the `prepare-release` skill. Let it decide the package and MCP API version axes, write the changelog, build the MCPB, bump versions, revert an unchanged API axis, verify the split, commit, push, and open the `development` to `main` PR.
+4. Report the selected package version, API-axis decision and reason, audit verdict, and PR URL. Stop at the open PR.
+
+Remember that `npm version` changes two independent axes. The package version moves every release. The MCP API version moves only for server/API contract changes. Never hand-edit the six version-bearing files or bump the API axis for dependency-only, refactor-only, or documentation-only releases. If a version or coverage judgment is ambiguous, state and justify the decision before proceeding.
+"""

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "^Bash$",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$(git rev-parse --show-toplevel)/.claude/hooks/integration-test-guard.mjs\"",
+            "timeout": 30,
+            "statusMessage": "Checking integration-test coverage"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,32 @@
 # Repository Guidelines
 
-## Project Structure
+## Project Structure & Module Organization
 
-- `src/`: MCP server core (core/, features/tools, prompts, resources, tdClient, server, api definitions, etc.)
-- `td/`: TouchDesigner-side Python modules and generated artifacts (modules/mcp, modules/td_server, templates, genHandlers.js, .tox)
-- `tests/`: Vitest tests (`unit/` and `integration/`)
-- `docs/`: Development guide, architecture, installation procedures
-- Distributions: `dist/` (build artifacts), `mcpb/` and `touchdesigner-mcp.mcpb` (MCP bundle)
+`src/` contains the TypeScript MCP server: shared logic is in `core/`, MCP features in `features/`, transport code in `transport/`, and TouchDesigner communication in `tdClient/`. The OpenAPI contract starts at `src/api/index.yml`. TouchDesigner-side Python, templates, generated artifacts, and `.tox` components live in `td/`. Tests belong in `tests/unit/` or `tests/integration/`, documentation in `docs/`, and media in `assets/`. Treat `dist/`, `src/gen/`, and `td/modules/td_server/` as generated output; edit their source schemas or templates instead.
 
 ## Build, Test, and Development Commands
 
-- Install dependencies: `npm install`
-- Build: `npm run build` (tsc + copy artifacts), `make build` (Docker-based)
-- Development inspector: `npm run dev` (stdio)
-- Start HTTP mode: `npm run http` (Prerequisites: built, TD on 9981 / HTTP on 6280)
-- Test: `npm test` (all), `npm run test:unit`, `npm run test:integration`, `npm run coverage`
-- Lint/Format: `npm run lint` (biome + tsc + ruff + prettier), `npm run format` (with fix)
-- Synchronize versions: `npm run version` (synchronizes API/Python/MCP)
-- Generate code: `npm run gen` (runs `gen:openapi` → `gen:handlers` → `gen:mcp`; no Docker/Java required)
-- MCP bundle: `npm run build:mcpb`
+- `npm install` installs Node dependencies.
+- `npm run build` regenerates code, compiles TypeScript, and copies runtime templates.
+- `make build` performs the Docker-based TouchDesigner module build.
+- `npm run dev` opens the MCP Inspector against the built stdio server.
+- `npm run http` starts HTTP mode on `127.0.0.1:6280`, targeting TouchDesigner on `9981`.
+- `npm test`, `npm run test:unit`, and `npm run test:integration` run all or scoped Vitest suites.
+- `npm run coverage` writes V8 reports; `npm run lint` runs all static checks.
+- `npm run gen` refreshes OpenAPI, Python handler, and TypeScript client output.
 
-## Coding Style and Naming
+## Coding Style & Naming Conventions
 
-- TypeScript: ESM, lint/format with `biome check`, type validation with `tsc --noEmit`. Folders are generally kebab-case, files camelCase, and types PascalCase.
-- Python (TD side): `ruff format` + `ruff check`. Generated code should be handled by modifying templates, not directly edited.
-- YAML/Documentation: Prettier (`**/*.{yml,yaml}`).
-- Compatibility Policy: MAJOR version mismatch or below `minApiVersion` will result in an error. MINOR differences will be a warning. PATCH differences are tolerated (#144).
+Use ESM TypeScript, tabs, and double quotes; let Biome organize imports. Use camelCase for files and functions, PascalCase for types, and generally kebab-case for directories. Python targets 3.9; Ruff enforces tabs, double quotes, and an 88-character line length. Run `npm run format` for automatic fixes. Keep changes focused.
 
 ## Testing Guidelines
 
-- Framework: Vitest (unit/integration). Mock with `vi.mock` / in-memory fakes (no MSW).
-- For compatibility or TD client related issues, please update or add existing test cases.
-- For new tests, name them in `tests/unit/*.test.ts` or `tests/integration/*.test.ts`.
+Name tests `*.test.ts` and place them in the appropriate unit or integration directory. Use Vitest globals and `vi.mock` or in-memory fakes. Add regression coverage for bug fixes, especially compatibility, transport, and TouchDesigner client changes. Run the narrow suite while developing, then `npm test` and `npm run lint` before submitting.
 
-## Commits and Pull Requests
+## Commit & Pull Request Guidelines
 
-- Commit example: `fix: ...`, `docs: ...`, `dev v1.4.2 (#142)`. Prefix + summary + PR number if applicable.
-- For PRs, include a summary of changes, verification steps (commands executed), and related issues/links (e.g., `#144`). For UI changes or artifact differences, provide a clear overview.
+Use concise imperative subjects with prefixes such as `feat:`, `fix:`, `test:`, `docs:`, `chore:`, and `release:`. Add issue or PR numbers when applicable, for example `fix: include Python traceback (#184)`. Pull requests should explain the change, link issues, list verification commands, and call out generated artifacts. Include screenshots for visible output changes.
 
-## Security and Configuration Tips
+## Security & Configuration Tips
 
-- The default connection destination for TouchDesigner is `127.0.0.1:9981`. For HTTP mode, specify using `--mcp-http-port`/`--mcp-http-host`.
-- If version compatibility is broken, check the README for update procedures and run `npm run version`.
+Keep local services bound to `127.0.0.1` unless remote access is intentional. Never commit credentials or machine-specific MCP configuration. After changing `package.json` versions, run `npm run version` to synchronize all metadata.


### PR DESCRIPTION
## Summary

Makes the repository's release tooling usable from Codex (not just Claude Code), and formalizes the two release-notes sections introduced in v1.5.0 — `### Upgrade Notes` and `### Contributors` — as part of the documented CHANGELOG format.

## Changes

### Codex support for the release workflow

- **`.codex/agents/release-manager.toml`** — Codex port of the `release-manager` agent: same fixed workflow (audit the release diff with `release-test-audit`, close gaps via `integration-test-guard`, cut the release with `prepare-release`, stop at the opened PR) and the same two-axis version rules.
- **`.agents/skills/*` symlinks** — expose `integration-test-guard`, `prepare-release`, `release-test-audit`, and `touchdesigner-self-debug` (which live under `.claude/skills/`) to Codex's skill discovery without duplicating their content.
- **`.codex/hooks.json`** — wires the existing pre-push guard into Codex's `PreToolUse(Bash)` hook, so a `git push` touching the MCP/API surface without an integration-test change is blocked in Codex too.
- **`.claude/hooks/integration-test-guard.mjs`** — made tool-agnostic (parses hook input defensively; documented as a Claude/Codex shared guard). No behavior change for Claude Code.
- **`AGENTS.md`** — rewritten as concise repository guidelines for coding agents: project structure, build/test commands, style conventions, testing expectations.

### CHANGELOG format: Upgrade Notes / Contributors

- **`.claude/skills/prepare-release/references/changelog-format.md`** — release entries now open with `### Upgrade Notes` (mandatory when the MCP API axis moves: what self-updates via `npx @latest`, what works without re-importing the `.tox`, what requires re-importing it, verified against `src/core/compatibility.ts`) and close with `### Contributors` (every human contributor, cross-checking commit authors, `Co-Authored-By` trailers, and PR authors so squash merges don't hide anyone; bots and AI co-author trailers excluded).
- **`.claude/skills/prepare-release/SKILL.md`** / **`.claude/agents/release-manager.md`** — Step 3 and the agent workflow now reference both bracketing sections, so future releases include them without rediscovery. Both were first applied in the v1.5.0 release notes (#197).

## Notes

- No runtime/shipped code changes: everything here is agent tooling and docs (`.claude/`, `.codex/`, `.agents/`, `AGENTS.md`). No version bump involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
