### PR TITLE
fix(deps): patch brace-expansion & body-parser Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2055,20 +2055,20 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+			"integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"debug": "^4.4.3",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.7.0",
+				"http-errors": "^2.0.1",
+				"iconv-lite": "^0.7.2",
 				"on-finished": "^2.4.1",
-				"qs": "^6.14.1",
-				"raw-body": "^3.0.1",
-				"type-is": "^2.0.1"
+				"qs": "^6.15.2",
+				"raw-body": "^3.0.2",
+				"type-is": "^2.1.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -2078,10 +2078,23 @@
 				"url": "https://opencollective.com/express"
 			}
 		},
+		"node_modules/body-parser/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.6",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4738,9 +4751,9 @@
 			"license": "MIT"
 		},
 		"node_modules/npm-run-all/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6456,17 +6469,34 @@
 			"optional": true
 		},
 		"node_modules/type-is": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-			"integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
 			"license": "MIT",
 			"dependencies": {
-				"content-type": "^1.0.5",
+				"content-type": "^2.0.0",
 				"media-typer": "^1.1.0",
 				"mime-types": "^3.0.0"
 			},
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
+			}
+		},
+		"node_modules/type-is/node_modules/content-type": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/typed-array-buffer": {


### PR DESCRIPTION
## Summary

Resolves the two open [Dependabot alerts](https://github.com/8beeeaaat/touchdesigner-mcp/security/dependabot) — a **lockfile-only** change (no `package.json` edit), since both patched versions fall within the semver ranges the parent packages already declare.

| Alert | Package | Severity | Before → After | Advisory |
|-------|---------|----------|----------------|----------|
| #158 | `brace-expansion` | high | `5.0.6 → 5.0.7` (also `1.1.14 → 1.1.16`) | GHSA-3jxr-9vmj-r5cp |
| #159 | `body-parser` | low | `2.2.2 → 2.3.0` | GHSA-v422-hmwv-36x6 |

Transitive bumps `type-is`/`content-type` are `body-parser@2.3.0`'s own updated dependencies.

## Why no `package.json` change
`express` already requires `body-parser@^2.2.1` and `minimatch` requires `brace-expansion@^5.0.5`; `npm update` re-resolved these to the patched versions within the existing ranges.

## Out of scope (intentionally)
`npm audit` also flags `hono`/`fast-uri`/`@hono/node-server`, but these are **not** Dependabot alerts and their only auto-fix path downgrades `@modelcontextprotocol/sdk` to 1.24.3 (breaking). Left untouched.

## Verification
- ✅ `npm audit` no longer reports `brace-expansion` or `body-parser`
- ✅ `npm run build` passes
- ✅ 254/254 unit tests pass (`npm run test:unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)