### PR TITLE
fix(deps): patch remaining 9 Dependabot alerts (transitive deps + overrides)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -772,12 +772,12 @@
 			}
 		},
 		"node_modules/@hono/node-server": {
-			"version": "1.19.13",
-			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
-			"integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+			"integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=18.14.1"
+				"node": ">=20"
 			},
 			"peerDependencies": {
 				"hono": "^4"
@@ -2896,9 +2896,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"funding": [
 				{
 					"type": "github",
@@ -3382,9 +3382,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.25",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+			"version": "4.12.31",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+			"integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -4022,9 +4022,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -4373,9 +4373,9 @@
 			}
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+			"integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5858,9 +5858,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.4",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-			"integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+			"integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,10 @@
 		"typescript": "6.0.3",
 		"vitest": "4.1.9"
 	},
+	"overrides": {
+		"@hono/node-server": "2.0.11",
+		"js-yaml": "4.3.0"
+	},
 	"type": "module",
 	"exports": {
 		".": {


### PR DESCRIPTION
## Summary

Resolves the remaining **9 open [Dependabot alerts](https://github.com/8beeeaaat/touchdesigner-mcp/security/dependabot)** (#160–#168). `npm audit` now reports **0 vulnerabilities**.

### Clean updates — within existing semver ranges (`npm update`)

| Alerts | Package | Update | Scope |
|--------|---------|--------|-------|
| #166, #168 | `fast-uri` | `3.1.2 → 3.1.4` | runtime |
| #163–#165 | `hono` | `4.12.25 → 4.12.31` | runtime (SDK allows `^4.11.4`) |
| #161 | `shell-quote` | `1.8.4 → 1.10.0` | dev |
| #167 | `linkify-it` | `5.0.1 → 5.0.2` | dev |

### Forced via `overrides` — a parent pins below the patched version

| Alert | Package | Override | Why needed |
|-------|---------|----------|-----------|
| #160 | `js-yaml` | `4.2.0 → 4.3.0` | `orval` pins **exactly** `4.2.0`; dev-only, same major — low risk |
| #162 | `@hono/node-server` | `1.19.13 → **2.0.11**` | MCP SDK pins `^1.19.9`; needs a major bump |

**Why `2.0.11` and not the minimal `2.0.5`:** while verifying, `npm audit` surfaced a *second* advisory — [GHSA-9mqv-5hh9-4cgg](https://github.com/advisories/GHSA-9mqv-5hh9-4cgg) (WebSocket-handshake memory-leak DoS) affecting `@hono/node-server` `2.0.0–2.0.9`. Targeting `2.0.11` closes both #162 and that one, avoiding a follow-up alert.

## Risk & verification of the `@hono/node-server` major bump

The SDK's `StreamableHTTPServerTransport` (used by this project's Express HTTP transport) top-level imports `getRequestListener` from `@hono/node-server`. Verified the 1.x→2.x override is safe:

- ✅ `getRequestListener` export still present in 2.0.11
- ✅ SDK `StreamableHTTPServerTransport` loads without error
- ✅ `tests/integration/httpTransport.test.ts` (5/5) — boots the transport and drives initialize / tools-list / session-DELETE / health (no live TouchDesigner needed), exercising the exact `@hono/node-server` path
- ✅ `npm run build` passes
- ✅ 254/254 unit tests pass
- ✅ `npm audit` → 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)