### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+## Summary
+
+<!-- What does this PR do, and why? Problem → approach. -->
+
+## Changes
+
+<!-- Bullet list of notable changes. Call out new MCP tools, OpenAPI schema changes, and template (.tox/.toe) changes explicitly. -->
+
+## How to verify
+
+<!-- Concrete steps a reviewer can run. -->
+<!-- For changes affecting TouchDesigner behavior, include live verification:
+     get_td_node_errors + get_top_image (black frame = fail). -->
+
+- [ ] `npm run build`
+- [ ] `npm test`
+
+## Breaking changes
+
+<!-- Renames, removed tools, schema changes, migration notes — or "None". -->
+
+## Related issues
+
+<!-- Closes #... -->
+
+---
+
+> Please keep PRs to a single reviewable unit. If your change bundles multiple
+> independent features, split it into separate (optionally stacked) PRs.


### PR DESCRIPTION
## Summary

Large multi-feature PRs with empty descriptions are effectively unreviewable, and the repo currently gives contributors no structure to follow. This adds a pull request template so every PR opens with a summary, verification steps, and breaking-change notes, and states the one-reviewable-unit policy up front.

## Changes

- Add `.github/PULL_REQUEST_TEMPLATE.md` with Summary / Changes / How to verify / Breaking changes / Related issues sections
- Embed this repo's live-TD verification convention (`get_td_node_errors` + `get_top_image`, black frame = fail) as an inline reminder
- Footer states the single-reviewable-unit policy for bundled-feature PRs

## How to verify

- [x] This PR's own body follows the template (dogfooding)
- [ ] After merge: open a new PR draft — GitHub auto-populates the body from `.github/PULL_REQUEST_TEMPLATE.md`
- `npm run build` / `npm test` — not applicable (docs-only, no code touched)

## Breaking changes

None.

## Related issues

Refs #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FLFVL759MZEjLHnGRcZWeM