### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-07-30
 
 ### Upgrade Notes
 
@@ -26,19 +26,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Updated the MCP protocol implementation to specification revision 2026-07-28: migrated from `@modelcontextprotocol/sdk` 1.29.0 to the SDK v2 packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`, `@modelcontextprotocol/express`, `@modelcontextprotocol/core` 2.0.0). stdio serving goes through `serveStdio` and HTTP serving through `createMcpHandler`, each serving 2026-07-28 and the 2025-era protocol from the same tool/prompt registrations. Responses now carry the revision's `resultType` field, list results the required `ttlMs`/`cacheScope` cache hints ([SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549)), and the standard `Mcp-Method`/`Mcp-Name` request headers are validated on the modern HTTP path ([SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)).
-- Tools are registered through the v2 `registerTool` API and prompts through `registerPrompt` with Zod argument schemas (replacing the deprecated variadic `server.tool()` and hand-written low-level `prompts/list` / `prompts/get` handlers). Tool and prompt wire behavior is unchanged apart from the new protocol fields.
-- HTTP mode shares a single `TouchDesignerClient` across the request-scoped server instances, so the TouchDesigner version-compatibility check result stays cached for its TTL instead of re-running on every stateless request.
-- `ConsoleLogger` renders non-string log data with `util.inspect`, preserving structured details that the MCP logging channel used to carry.
+- Updated the MCP protocol implementation to specification revision 2026-07-28: migrated from `@modelcontextprotocol/sdk` 1.29.0 to the SDK v2 packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`, `@modelcontextprotocol/express`, `@modelcontextprotocol/core` 2.0.0). stdio serving goes through `serveStdio` and HTTP serving through `createMcpHandler`, each serving 2026-07-28 and the 2025-era protocol from the same tool/prompt registrations. Responses now carry the revision's `resultType` field, list results the required `ttlMs`/`cacheScope` cache hints ([SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549)), and the standard `Mcp-Method`/`Mcp-Name` request headers are validated on the modern HTTP path ([SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)) ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+- Tools are registered through the v2 `registerTool` API and prompts through `registerPrompt` with Zod argument schemas (replacing the deprecated variadic `server.tool()` and hand-written low-level `prompts/list` / `prompts/get` handlers). Tool and prompt wire behavior is unchanged apart from the new protocol fields ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+- HTTP mode shares a single `TouchDesignerClient` across the request-scoped server instances, so the TouchDesigner version-compatibility check result stays cached for its TTL instead of re-running on every stateless request ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+- `ConsoleLogger` renders non-string log data with `util.inspect`, preserving structured details that the MCP logging channel used to carry ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+- Released version `2.0.0` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB download URL and checksum so npm and MCPB installations resolve the same release. The major bump reflects the breaking changes above (Node.js 20+ requirement, HTTP session removal, MCP logging capability removal). The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) stays at `1.5.0` since this release contains no server/API contract changes — no `.tox` re-import is required.
 
 ### Removed
 
-- Removed the session management layer (`TransportFactory`, `TransportRegistry`, `SessionManager`, `SessionConfig`) — protocol revision 2026-07-28 makes Streamable HTTP stateless, serving every request with a fresh server instance.
-- Removed the deprecated MCP `logging` capability and the `McpLogger`; logging now writes to stderr (SEP-2577 migration path).
+- Removed the session management layer (`TransportFactory`, `TransportRegistry`, `SessionManager`, `SessionConfig`) — protocol revision 2026-07-28 makes Streamable HTTP stateless, serving every request with a fresh server instance ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+- Removed the deprecated MCP `logging` capability and the `McpLogger`; logging now writes to stderr (SEP-2577 migration path) ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+
+### Security
+
+- Patched all open Dependabot alerts: bumped `brace-expansion` and `body-parser` ([#200](https://github.com/8beeeaaat/touchdesigner-mcp/pull/200)), then resolved the remaining 9 alerts in transitive dependencies via targeted bumps and npm `overrides` ([#201](https://github.com/8beeeaaat/touchdesigner-mcp/pull/201)).
 
 ### Technical
 
-- Added an E2E test suite (`npm run test:e2e`, also run in CI) that spawns the built `dist/cli.js` and drives it with the real MCP SDK v2 client (`@modelcontextprotocol/client`) over both transports: 2026-07-28 negotiation via `server/discover` (auto and pinned modes), the 2025-era legacy fallback, `tools/list` / `tools/call` / `prompts/get`, and the stateless `/health` shape. Readiness uses health-endpoint polling rather than fixed sleeps; no TouchDesigner instance is required.
+- Added an E2E test suite (`npm run test:e2e`, also run in CI) that spawns the built `dist/cli.js` and drives it with the real MCP SDK v2 client (`@modelcontextprotocol/client`) over both transports: 2026-07-28 negotiation via `server/discover` (auto and pinned modes), the 2025-era legacy fallback, `tools/list` / `tools/call` / `prompts/get`, and the stateless `/health` shape. Readiness uses health-endpoint polling rather than fixed sleeps; no TouchDesigner instance is required. The `integration-test-guard` pre-push hook accepts `tests/e2e/` changes as coverage evidence ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
+- Ported the maintainer release tooling to Codex and formalized the CHANGELOG's `Upgrade Notes` / `Contributors` sections in the release skills ([#198](https://github.com/8beeeaaat/touchdesigner-mcp/pull/198)); added and refined a pull-request template ([#203](https://github.com/8beeeaaat/touchdesigner-mcp/pull/203), [#204](https://github.com/8beeeaaat/touchdesigner-mcp/pull/204)).
+- **Dependency Updates**: replaced the MCP SDK and hardened transitive dependencies.
+  - `@modelcontextprotocol/sdk` 1.29.0 → `@modelcontextprotocol/server` / `node` / `express` / `core` ^2.0.0 (runtime), `@modelcontextprotocol/client` ^2.0.0 (dev, E2E tests)
+  - Dependabot fixes for `brace-expansion`, `body-parser`, and 9 transitive alerts via `overrides` ([#200](https://github.com/8beeeaaat/touchdesigner-mcp/pull/200), [#201](https://github.com/8beeeaaat/touchdesigner-mcp/pull/201))
+
+### Contributors
+
+- [@8beeeaaat](https://github.com/8beeeaaat) — MCP protocol revision 2026-07-28 migration, stateless transports, and E2E suite ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)); release tooling port ([#198](https://github.com/8beeeaaat/touchdesigner-mcp/pull/198)); dependency security patches ([#200](https://github.com/8beeeaaat/touchdesigner-mcp/pull/200), [#201](https://github.com/8beeeaaat/touchdesigner-mcp/pull/201)); PR template ([#203](https://github.com/8beeeaaat/touchdesigner-mcp/pull/203), [#204](https://github.com/8beeeaaat/touchdesigner-mcp/pull/204))
 
 ## [1.5.0] - 2026-07-11
 

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "touchdesigner-mcp",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "display_name": "TouchDesigner MCP Server",
   "description": "AI assistant for TouchDesigner - control nodes, execute Python scripts, and create interactive visual content",
   "long_description": "# TouchDesigner MCP Server\n\nBridge between AI assistants and TouchDesigner for creative coding and visual programming. Features include:\n\n- **Node Operations**: Create, delete, and modify TouchDesigner nodes\n- **Python Execution**: Run Python scripts directly in TouchDesigner environment\n- **Parameter Control**: Update node parameters and connections\n- **Real-time Monitoring**: Get TouchDesigner server information and node details\n- **Creative Assistance**: AI-powered workflow optimization and debugging\n- **Code Execution Manifest**: Generate filesystem-style tool manifests (`describe_td_tools`) for code-mode agents\n\nPerfect for visual artists, creative coders, and interactive media developers who want to leverage AI for TouchDesigner projects.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "touchdesigner-mcp-server",
-			"version": "1.5.0",
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"@modelcontextprotocol/core": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "touchdesigner-mcp-server",
-	"version": "1.5.0",
+	"version": "2.0.0",
 	"description": "MCP server for TouchDesigner",
 	"repository": {
 		"type": "git",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
   "name": "io.github.8beeeaaat/touchdesigner-mcp-server",
   "description": "MCP server for TouchDesigner - Control and operate TouchDesigner projects through AI agents",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "repository": {
     "url": "https://github.com/8beeeaaat/touchdesigner-mcp.git",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "touchdesigner-mcp-server",
-      "version": "1.5.0",
+      "version": "2.0.0",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"
@@ -19,9 +19,9 @@
     },
     {
       "registryType": "mcpb",
-      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v1.5.0/touchdesigner-mcp.mcpb",
-      "version": "1.5.0",
-      "fileSha256": "10d021b61c8d7fedd55cc0c0c64d3651c475a4fcab6f1e4f8aa7eb2b0a117b97",
+      "identifier": "https://github.com/8beeeaaat/touchdesigner-mcp/releases/download/v2.0.0/touchdesigner-mcp.mcpb",
+      "version": "2.0.0",
+      "fileSha256": "fcf7516a363c98c6ad6d7296ace74a09cf7c178a051c7eb511abbd48f1ada9fa",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## [2.0.0] - 2026-07-30

### Upgrade Notes

**For MCP client users** (Claude Desktop, other MCP hosts — npx or MCPB installs):

- **No configuration changes needed.** The server now speaks MCP protocol revision [2026-07-28](https://modelcontextprotocol.io/specification/2026-07-28/changelog) and transparently falls back to the 2025-era protocol for existing clients, in both stdio and HTTP modes. Clients that already understand 2026-07-28 negotiate it automatically via `server/discover`.
- **The TouchDesigner side is untouched.** No `.tox` re-import is required; all 14 tools and 3 prompts behave identically. In HTTP mode, the TouchDesigner version-compatibility check result is now shared across requests for its TTL, so the per-request stateless serving does not re-run the handshake on every call.
- **Node.js 20+ is now required** to run the server (SDK v2 requirement; declared in `engines` and the MCPB manifest). Check `node --version` where the MCP host spawns the server.
- **HTTP mode is now stateless.** Protocol revision 2026-07-28 removes protocol-level sessions ([SEP-2567](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567)): the `Mcp-Session-Id` header is no longer issued or accepted, `GET`/`DELETE` on `/mcp` answer `405` (SDK clients tolerate both), and the `/health` response no longer reports a `sessions` count — update any monitoring that read it. Deployments can now sit behind ordinary round-robin load balancers.
- **Server logs moved to stderr.** The MCP logging capability is deprecated by the specification ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577)), so log messages no longer arrive over the MCP connection's logging channel — read them from the host's stderr capture (e.g. Claude Desktop's MCP log files) instead.

**For developers** (contributors to this repository):

- The SDK dependency changed from `@modelcontextprotocol/sdk` 1.x to the v2 packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`, `@modelcontextprotocol/express`, `@modelcontextprotocol/core`). Tools are registered with `registerTool` and prompts with `registerPrompt` (Zod schemas) — the v1 `server.tool()` and low-level schema-based `setRequestHandler` forms no longer exist.
- The transport layer is much smaller: stdio serving goes through `serveStdio(factory)`, HTTP through `createMcpHandler(factory)` + `toNodeHandler` inside `ExpressHttpManager`. The session machinery (`TransportFactory`, `TransportRegistry`, `SessionManager`, ~1,000 lines) is gone; there is no per-session state to reason about.
- `ILogger` is now SDK-independent (`LogParams` in `src/core/logger.ts`); `ConsoleLogger` (stderr) is the only implementation and renders structured data via `util.inspect`.
- New `npm run test:e2e` suite (also run in CI) drives the built `dist/cli.js` with the real MCP SDK v2 client over both transports and both protocol eras; the `integration-test-guard` pre-push hook accepts `tests/e2e/` changes as coverage evidence alongside `tests/integration/`.

### Changed

- Updated the MCP protocol implementation to specification revision 2026-07-28: migrated from `@modelcontextprotocol/sdk` 1.29.0 to the SDK v2 packages (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`, `@modelcontextprotocol/express`, `@modelcontextprotocol/core` 2.0.0). stdio serving goes through `serveStdio` and HTTP serving through `createMcpHandler`, each serving 2026-07-28 and the 2025-era protocol from the same tool/prompt registrations. Responses now carry the revision's `resultType` field, list results the required `ttlMs`/`cacheScope` cache hints ([SEP-2549](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2549)), and the standard `Mcp-Method`/`Mcp-Name` request headers are validated on the modern HTTP path ([SEP-2243](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2243)) ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
- Tools are registered through the v2 `registerTool` API and prompts through `registerPrompt` with Zod argument schemas (replacing the deprecated variadic `server.tool()` and hand-written low-level `prompts/list` / `prompts/get` handlers). Tool and prompt wire behavior is unchanged apart from the new protocol fields ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
- HTTP mode shares a single `TouchDesignerClient` across the request-scoped server instances, so the TouchDesigner version-compatibility check result stays cached for its TTL instead of re-running on every stateless request ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
- `ConsoleLogger` renders non-string log data with `util.inspect`, preserving structured details that the MCP logging channel used to carry ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
- Released version `2.0.0` across package metadata (`package.json`), MCP bundle manifest (`mcpb/manifest.json`), and server registry metadata (`server.json`), including the updated MCPB download URL and checksum so npm and MCPB installations resolve the same release. The major bump reflects the breaking changes above (Node.js 20+ requirement, HTTP session removal, MCP logging capability removal). The MCP API version (`src/api/index.yml`, `td/modules/utils/version.py`, `pyproject.toml`) stays at `1.5.0` since this release contains no server/API contract changes — no `.tox` re-import is required.

### Removed

- Removed the session management layer (`TransportFactory`, `TransportRegistry`, `SessionManager`, `SessionConfig`) — protocol revision 2026-07-28 makes Streamable HTTP stateless, serving every request with a fresh server instance ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
- Removed the deprecated MCP `logging` capability and the `McpLogger`; logging now writes to stderr (SEP-2577 migration path) ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).

### Security

- Patched all open Dependabot alerts: bumped `brace-expansion` and `body-parser` ([#200](https://github.com/8beeeaaat/touchdesigner-mcp/pull/200)), then resolved the remaining 9 alerts in transitive dependencies via targeted bumps and npm `overrides` ([#201](https://github.com/8beeeaaat/touchdesigner-mcp/pull/201)).

### Technical

- Added an E2E test suite (`npm run test:e2e`, also run in CI) that spawns the built `dist/cli.js` and drives it with the real MCP SDK v2 client (`@modelcontextprotocol/client`) over both transports: 2026-07-28 negotiation via `server/discover` (auto and pinned modes), the 2025-era legacy fallback, `tools/list` / `tools/call` / `prompts/get`, and the stateless `/health` shape. Readiness uses health-endpoint polling rather than fixed sleeps; no TouchDesigner instance is required. The `integration-test-guard` pre-push hook accepts `tests/e2e/` changes as coverage evidence ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)).
- Ported the maintainer release tooling to Codex and formalized the CHANGELOG's `Upgrade Notes` / `Contributors` sections in the release skills ([#198](https://github.com/8beeeaaat/touchdesigner-mcp/pull/198)); added and refined a pull-request template ([#203](https://github.com/8beeeaaat/touchdesigner-mcp/pull/203), [#204](https://github.com/8beeeaaat/touchdesigner-mcp/pull/204)).
- **Dependency Updates**: replaced the MCP SDK and hardened transitive dependencies.
  - `@modelcontextprotocol/sdk` 1.29.0 → `@modelcontextprotocol/server` / `node` / `express` / `core` ^2.0.0 (runtime), `@modelcontextprotocol/client` ^2.0.0 (dev, E2E tests)
  - Dependabot fixes for `brace-expansion`, `body-parser`, and 9 transitive alerts via `overrides` ([#200](https://github.com/8beeeaaat/touchdesigner-mcp/pull/200), [#201](https://github.com/8beeeaaat/touchdesigner-mcp/pull/201))

### Contributors

- [@8beeeaaat](https://github.com/8beeeaaat) — MCP protocol revision 2026-07-28 migration, stateless transports, and E2E suite ([#206](https://github.com/8beeeaaat/touchdesigner-mcp/pull/206)); release tooling port ([#198](https://github.com/8beeeaaat/touchdesigner-mcp/pull/198)); dependency security patches ([#200](https://github.com/8beeeaaat/touchdesigner-mcp/pull/200), [#201](https://github.com/8beeeaaat/touchdesigner-mcp/pull/201)); PR template ([#203](https://github.com/8beeeaaat/touchdesigner-mcp/pull/203), [#204](https://github.com/8beeeaaat/touchdesigner-mcp/pull/204))
