### PR TITLE
fix(deps): patch 3 security advisories in transitive deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2932,9 +2932,9 @@
 			}
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+			"integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3419,9 +3419,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.31",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
-			"integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+			"version": "4.13.0",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+			"integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
 			"license": "MIT",
 			"peer": true,
 			"engines": {
@@ -4053,9 +4053,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"dev": true,
 			"funding": [
 				{

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"overrides": {
 		"@hono/node-server": "2.0.11",
-		"js-yaml": "4.3.0"
+		"js-yaml": "4.3.1"
 	},
 	"type": "module",
 	"exports": {


### PR DESCRIPTION
## Summary

Triage of the two open Dependabot alerts, plus one advisory that **only `npm audit` surfaces**. All three are in-range or same-minor bumps, so the diff is `package-lock.json` plus a single line in `overrides`.

Two things came out of the triage worth flagging:

1. **GitHub's severity ordering inverts against this project's actual exposure.** The High (7.5) one is dev-only and parses our own schema; the Medium (5.3) one is runtime-scoped but its vulnerable function is unreachable. Both are patched anyway because the bumps are free.
2. **The Dependabot page alone was not a complete triage surface.** `npm audit` found a high-severity js-yaml advisory that Dependabot has no alert for in any state (open / dismissed / fixed) — and our existing `overrides` pin, `4.3.0`, sits inside its vulnerable range.

## Changes

| Package | Change | Advisory | Scope |
|---|---|---|---|
| `fast-uri` | 3.1.4 → 3.1.5 | GHSA-7p8r-x3mc-p8w7 — host confusion via backslash authority introducer (dependabot alert 174, CVSS 7.5) | dev |
| `hono` | 4.12.31 → 4.13.0 | GHSA-8j4g-w8fx-2239 — ReDoS in CORS middleware (dependabot alert 172, CVSS 5.3) | runtime |
| `js-yaml` (override) | 4.3.0 → 4.3.1 | GHSA-5p4m-2wfm-xmqj — quadratic CPU in `!!omap` resolution (CVSS high) | dev |

`npm audit`: **5 → 1**. The remaining one is `brace-expansion` (dev-scope DoS), already auto-dismissed by Dependabot.

No MCP tools, OpenAPI schema, or `.tox` templates changed.

### Why each is low actual risk (patched regardless)

- **`fast-uri`** — dev-only, reached via `@redocly/cli` / `orval` → `@scalar/openapi-parser` → `ajv`. It resolves `$ref` / `$id` in **our own** `src/api/index.yml` at codegen time, and `files: ["dist/**/*"]` keeps it out of the published tarball. Host confusion matters when the parse result feeds a security decision; schema reference resolution is not that.
- **`hono`** — runtime-scoped, but **nothing in the dependency tree imports `hono/cors`**. Verified across `@modelcontextprotocol/{core,server,node,express}`, `@hono/node-server`, and `src/`. `@modelcontextprotocol/node` pulls only `getRequestListener`.
  Note this is **not** the Express CORS path: `@modelcontextprotocol/express` depends on the separate `cors@^2.8.5` package, a different advisory surface. Also, npm consumers already resolve `hono@4.13.0` — the alert exists only because our lockfile pinned 4.12.31.
- **`js-yaml`** — dev-only. The override is still required because `orval` pins `js-yaml` at exactly `4.2.0`; only the target moves, 4.3.0 → 4.3.1.

### `@hono/node-server` override: intentionally left at 2.0.11

`@modelcontextprotocol/node@2.0.0` declares `^1.19.9`, and GHSA-frvp-7c67-39w9 has **no 1.x fix** (`< 2.0.5`, single range), so the forced major is the only way to close that alert. Updating upstream does not help — 2.0.0 is `latest` and every published version back to alpha declares `^1.19.9`.

Two caveats recorded for later:

- `overrides` is root-project-only, so **npm and mcpb consumers still resolve 1.19.17**. The vulnerable `serve-static` path is unreachable from this project, but the override is not protecting downstream users — only this repo's CI and Docker image.
- The real fix is upstream widening its range to `^2`.

## How to verify

- [x] `npm run build` — `npm run gen` produced **zero output diff**, confirming `orval` works on js-yaml 4.3.1; `build:dist` (tsc) clean
- [x] `npm test` — partial, see the table below

| Suite | Result |
|---|---|
| `test:unit` | 201 passed (17 files) |
| `test:e2e` | 6 passed (stdio + Streamable HTTP) |
| `test:integration` | **not run** — see below |

`test:integration` was not validated. CI (`development.yml`) runs only `test:unit` and `test:e2e`, so **this PR's green check does not cover the integration suite**. Locally it could not be validated either: the running TouchDesigner instance had loaded its Python modules from a different working copy, not this checkout.

Grounds for merging without it: the `td/modules` sources were byte-identical apart from `__pycache__`, the diff is three transitive version bumps with no source change, and neither `fast-uri` (dev-only) nor `hono` (unreachable) sits on the `TouchDesignerClient` (axios → HTTP) path that the integration suite exercises. Anyone with a TouchDesigner instance bound to this checkout can close the gap with `npm run test:integration`.

The passing `tests/e2e/http.e2e.test.ts` also exercises `toNodeHandler` → `getRequestListener` against `@hono/node-server@2.0.11`, which re-validates the forced major on the current SDK v2 wiring — PR #201's original check predates the SDK v2 migration.

## Breaking changes

None. Runtime behavior is unchanged; `package.json` moves by one version token in `overrides`.

## Related issues

None. The `dependabot alert NNN` references above are Dependabot alert numbers, not issues or PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)