### PR TITLE
fix(deps): bump orval to 8.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"@types/semver": "7.7.1",
 				"@vitest/coverage-v8": "4.1.9",
 				"npm-run-all": "4.1.5",
-				"orval": "8.19.0",
+				"orval": "8.22.0",
 				"prettier": "3.8.5",
 				"shx": "0.4.0",
 				"typescript": "6.0.3",
@@ -957,29 +957,29 @@
 			}
 		},
 		"node_modules/@orval/angular": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.19.0.tgz",
-			"integrity": "sha512-w3sBRPCVmZDlpbSGyBhVsrleMsrD63AzxYOFfLx+I/Wy6FxN1xartlOUGGyroQMFLDx+Lk74+olQQp6IVnRerg==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/angular/-/angular-8.22.0.tgz",
+			"integrity": "sha512-lSvaNj+VHGIWBQOG104HfPNrk2xGjpArwy67u6ZBPzHo/OtDE5Tm1t+ARYseCOElFr4z3i3A62qjFLFy6zj00Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0"
+				"@orval/core": "8.22.0"
 			}
 		},
 		"node_modules/@orval/axios": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.19.0.tgz",
-			"integrity": "sha512-Y8Unxm5AidLV7M9TZH4R2KESnIvnlx/Xueis8TaOV2lk7y8sR8s2wDhc4OgFc838YyuQjpHZe+7LDs/zV0BNdA==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/axios/-/axios-8.22.0.tgz",
+			"integrity": "sha512-fFu0UgTbpI9a1ayM7qCs55MMy6MlVgOpE3BBXGukCTBSwNwFLN47WdzQev/x0mAcs58pNKYT0KL4R9MXGnmgfg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0"
+				"@orval/core": "8.22.0"
 			}
 		},
 		"node_modules/@orval/core": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/core/-/core-8.19.0.tgz",
-			"integrity": "sha512-ytCtxmHwjUsrboTBwi22FUatfnM+4sYLu/XUOLbqHfteU5WmOmGuzHqwndlFTpN9IRY2XHhKRMyZG7IZ2f2Bww==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/core/-/core-8.22.0.tgz",
+			"integrity": "sha512-uKYi7+Smg6oQ2MxE0AS2FNI7bwssoxGLh391Uk0FU+DcTcSv9q2GmvoM8uwd827Hok29kD7AegHE8Mhmsa5uWg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -991,6 +991,7 @@
 				"esutils": "2.0.3",
 				"fs-extra": "^11.3.2",
 				"jiti": "^2.6.1",
+				"jsesc": "^3.0.0",
 				"remeda": "^2.33.6",
 				"tinyglobby": "^0.2.16",
 				"typedoc": "^0.28.19"
@@ -1005,35 +1006,35 @@
 			}
 		},
 		"node_modules/@orval/effect": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/effect/-/effect-8.19.0.tgz",
-			"integrity": "sha512-Tw69OcBsi3eNyQkCv8W9dmNTlVzjO8q9BnLQ/A5MhksGHHecr5nW6AIINSkkAm+3e2dURbLdvC5trxAqsZtg4w==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/effect/-/effect-8.22.0.tgz",
+			"integrity": "sha512-DACiw2+0ZsPJPKQbYlb9qFFFppaCBaT/HgIq2S1asH9ZCOOTZKm9VrRXpeCWINHC2w1BpdSATpytv+61UT5Y/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
+				"@orval/core": "8.22.0",
 				"remeda": "^2.33.6"
 			}
 		},
 		"node_modules/@orval/fetch": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.19.0.tgz",
-			"integrity": "sha512-Dn6Tau2RRJeuS+n5A16cNbKZDVsi204O+sAcpa2Qro4eI2vJvXBP0XCy1eJXQ27FRkjH6t1Bsw/SSKKvnGEtxw==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/fetch/-/fetch-8.22.0.tgz",
+			"integrity": "sha512-G0r6hOdZG963H/8S4Vk1kWfU/hkQC/cwpDZL+mzcXgzrdG9NDloshTqmge/jP5lPsFAwfcRUmmts10OmuIE4BQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0"
+				"@orval/core": "8.22.0"
 			}
 		},
 		"node_modules/@orval/hono": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.19.0.tgz",
-			"integrity": "sha512-w45nT8MleH9UDbiQJ2XXNoLeIwEnpCIFpja3cJlrdosabHfoFY/yxdKfrpKnGM73wvYWAxni2Wn+x4dhB15owg==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/hono/-/hono-8.22.0.tgz",
+			"integrity": "sha512-GMCpGZqCuGYSu10KTt2q3WYzCqEcTGxr18z3HgHv9dX22sv/V76dlLBh3SE72xp8Z7/jmoq3GKBdgU9k98ju0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
-				"@orval/zod": "8.19.0",
+				"@orval/core": "8.22.0",
+				"@orval/zod": "8.22.0",
 				"fs-extra": "^11.3.2"
 			},
 			"peerDependencies": {
@@ -1046,69 +1047,70 @@
 			}
 		},
 		"node_modules/@orval/mcp": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.19.0.tgz",
-			"integrity": "sha512-PDcGCZvpIRyAuvCwl2vy6mh45wJVztkBDLwiyWZNbnT74yj2tjeMeqee05ocauQyjWHVtsbjioP5NeaaWP1+zg==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/mcp/-/mcp-8.22.0.tgz",
+			"integrity": "sha512-ySa4EenAF8YMCpbmddJGO3lItTPC8Uf/iT+P2ezaowVgxOCPX/fjG7dd0fnVmrr0vaphi53yWx5o5DlT17FzLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
-				"@orval/fetch": "8.19.0",
-				"@orval/zod": "8.19.0"
+				"@orval/core": "8.22.0",
+				"@orval/fetch": "8.22.0",
+				"@orval/zod": "8.22.0"
 			}
 		},
 		"node_modules/@orval/mock": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.19.0.tgz",
-			"integrity": "sha512-mhqHMcy3wVD7UjW9/obwzJqAlElOPG3r6wcImQyl2eKWATYOcqO/jvFAfd7D3WEXfPjDqV71TDUtFToSsUXtbQ==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/mock/-/mock-8.22.0.tgz",
+			"integrity": "sha512-ZCEFpdi4z+YOCg0Tsgz6DO/M1TSfYxE5urDWJgYNUKeD8XDEHFb2IgTiiaAwJunqWnRQuiMfGp9G81+u10Kx6w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
+				"@orval/core": "8.22.0",
 				"remeda": "^2.33.6"
 			}
 		},
 		"node_modules/@orval/query": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/query/-/query-8.19.0.tgz",
-			"integrity": "sha512-i5a37W+gGZ6lLlaYEXlmgfnGdxbXdBRhjzWxCLX23hrLsYZGPQ6tcbFxM116abm7giax4mxCMjtR57ceGdq6xw==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/query/-/query-8.22.0.tgz",
+			"integrity": "sha512-IH9049z860CLUeGEezGv+yOvUvcAyDnd9doDe1Ryi0WxsDul2Vh3LjCRUEQf4JZiyZezadWYYGzs0lwnCn/afA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
-				"@orval/fetch": "8.19.0",
+				"@orval/core": "8.22.0",
+				"@orval/fetch": "8.22.0",
 				"remeda": "^2.33.6"
 			}
 		},
 		"node_modules/@orval/solid-start": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.19.0.tgz",
-			"integrity": "sha512-196pvkS31R05WJp1nBDTKsg9PJLe1eAyxFt3BZN5wlbgUaX+GmPq68zb/v2pgUHnLTgt2LwpXkaLBovu0m+Saw==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/solid-start/-/solid-start-8.22.0.tgz",
+			"integrity": "sha512-Q1ZCWOrA6/VJnyj62XpPxXti9NpAA4lDZVqPL2uQ5gbxv+T+azEaazKqYIpSBJXbl1aEezujdcyg/DVUakWKEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0"
+				"@orval/core": "8.22.0"
 			}
 		},
 		"node_modules/@orval/swr": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.19.0.tgz",
-			"integrity": "sha512-0TPNEjzhxPTHI0zrtvySV13dPJ5E7fP15NIh2nv1FR8CXBzjp9HN51AFw910y78ehxb9RrxSMkoz8WMpwdK/7A==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/swr/-/swr-8.22.0.tgz",
+			"integrity": "sha512-OSeWX3Af8ESapKIo3XpbOaTMaG8oeEtuucFyOUauqg6NyC6/9Ikcf2csBdF0AuIKA0QTcjcXxra/ccj1f7KnRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
-				"@orval/fetch": "8.19.0"
+				"@orval/core": "8.22.0",
+				"@orval/fetch": "8.22.0"
 			}
 		},
 		"node_modules/@orval/zod": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.19.0.tgz",
-			"integrity": "sha512-8o2MZ3eGzQMRz2j0C4YvL8J+e1lYgA6oo6aTiizoqrgmXKLdMqFaoz1SWB0UoEYCURmhPEohfrGm3J1+SRcI9Q==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/@orval/zod/-/zod-8.22.0.tgz",
+			"integrity": "sha512-briHtUTz79fvCeIFfGW3IbmUIF9DOotUoWFa/sKUjRUG8PMGDWSjQzO8QdLzLoETVGo9g4TfGwp5Xjcs81GZTA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@orval/core": "8.19.0",
+				"@orval/core": "8.22.0",
+				"jsesc": "^3.0.0",
 				"remeda": "^2.33.6"
 			}
 		},
@@ -1908,9 +1910,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.17.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+			"integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3101,9 +3103,9 @@
 			}
 		},
 		"node_modules/fs-extra": {
-			"version": "11.3.5",
-			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-			"integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+			"integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4073,6 +4075,19 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsesc": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+			"integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/json-parse-better-errors": {
@@ -5046,25 +5061,25 @@
 			}
 		},
 		"node_modules/orval": {
-			"version": "8.19.0",
-			"resolved": "https://registry.npmjs.org/orval/-/orval-8.19.0.tgz",
-			"integrity": "sha512-P/DFRVm4F/NZVg42x3K2/iUxPl3EWvuBLLxUPdxVqm2tOg7fAD1mqrigBpd3cg1DqXhN1PsD8bktLH8BMLh1Wg==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/orval/-/orval-8.22.0.tgz",
+			"integrity": "sha512-N8UmB4DOhW+Z2SzVq4oS/pN3DsRPq+msrRU8NyRldP1i0yiqT6qo8mUxHPk2umqYjyY0FlR2mvPbi/Jf5CiP7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@commander-js/extra-typings": "^15.0.0",
-				"@orval/angular": "8.19.0",
-				"@orval/axios": "8.19.0",
-				"@orval/core": "8.19.0",
-				"@orval/effect": "8.19.0",
-				"@orval/fetch": "8.19.0",
-				"@orval/hono": "8.19.0",
-				"@orval/mcp": "8.19.0",
-				"@orval/mock": "8.19.0",
-				"@orval/query": "8.19.0",
-				"@orval/solid-start": "8.19.0",
-				"@orval/swr": "8.19.0",
-				"@orval/zod": "8.19.0",
+				"@orval/angular": "8.22.0",
+				"@orval/axios": "8.22.0",
+				"@orval/core": "8.22.0",
+				"@orval/effect": "8.22.0",
+				"@orval/fetch": "8.22.0",
+				"@orval/hono": "8.22.0",
+				"@orval/mcp": "8.22.0",
+				"@orval/mock": "8.22.0",
+				"@orval/query": "8.22.0",
+				"@orval/solid-start": "8.22.0",
+				"@orval/swr": "8.22.0",
+				"@orval/zod": "8.22.0",
 				"@scalar/json-magic": "^0.12.16",
 				"@scalar/openapi-parser": "^0.28.7",
 				"@scalar/openapi-types": "0.8.0",
@@ -5553,9 +5568,9 @@
 			}
 		},
 		"node_modules/remeda": {
-			"version": "2.39.0",
-			"resolved": "https://registry.npmjs.org/remeda/-/remeda-2.39.0.tgz",
-			"integrity": "sha512-3Ki8dU1o3OVu4dwIQ2Pj+yiuP7OnEbmWAGmJ3yDRqopily5jsj8NWzPvbS89H85d6UdONKEcUnrfuHY6jN9vyw==",
+			"version": "2.45.0",
+			"resolved": "https://registry.npmjs.org/remeda/-/remeda-2.45.0.tgz",
+			"integrity": "sha512-CTftZ0GJSox3CH77OhJemj20sXXUScH/kpkExD6t2LP3IG+mPKASBMFkbvWtsvzhU+54gKcgH38WWVihfr7bCA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@types/semver": "7.7.1",
 		"@vitest/coverage-v8": "4.1.9",
 		"npm-run-all": "4.1.5",
-		"orval": "8.19.0",
+		"orval": "8.22.0",
 		"prettier": "3.8.5",
 		"shx": "0.4.0",
 		"typescript": "6.0.3",


### PR DESCRIPTION
Updates `orval` to address 12 advisories, including RCE and SSRF at generation time.

Cleared: GHSA-2h9g-j24r-h63g, GHSA-2w86-xfrc-g85r, GHSA-3575-w9fc-c2j6, GHSA-6437-gxhq-pqv8, GHSA-653q-5476-x79g, GHSA-88f2-fpv8-89q2, GHSA-8j6p-r8jg-mxqh, GHSA-cxq5-97v7-87j8, GHSA-fg9p-mrxr-hvq7, GHSA-w727-8j6c-2rj4, GHSA-6mr6-jvcr-2f25, GHSA-p4cg-3328-rvfg.

Evidence:
- `package.json` referenced `orval@8.19.0`
- OSV reports the 12 advisories above for `orval@8.19.0`
- updated version: `8.22.0` (lowest release clear of all of them)

Validation:
- OSV reports no advisory for `orval@8.22.0`
- `npm run gen:mcp` succeeds with 8.22.0
- `npm run test:unit` passes: 205/205
- `npm run lint:tsc`, `lint:biome`, `lint:yaml` pass (`lint:python` needs `ruff`, not installed here)
- `npm run test:integration` requires a live TouchDesigner instance on port 9981, so it was not run locally

Scope: dependency update only (`package.json`, `package-lock.json`).
